### PR TITLE
Add React Native Windows telemetry configuration

### DIFF
--- a/tools/_react-native-windows.nix
+++ b/tools/_react-native-windows.nix
@@ -1,0 +1,12 @@
+# Not supported via environment variable.
+# Opt-out requires CLI flag: --no-telemetry
+# Example: npx @react-native-community/cli run-windows --no-telemetry
+{
+  name = "react-native-windows";
+  meta = {
+    description = "React Native for Windows";
+    homepage = "https://github.com/microsoft/react-native-windows";
+    documentation = "https://microsoft.github.io/react-native-windows/docs/run-windows-cli";
+  };
+  variables = { };
+}


### PR DESCRIPTION
## Summary
Added telemetry configuration for React Native Windows CLI tool to the tools directory.

## Key Changes
- Created new `_react-native-windows.nix` configuration file
- Documented that telemetry is not supported via environment variables
- Noted that opt-out requires the `--no-telemetry` CLI flag
- Included project metadata (description, homepage, documentation links)
- Set up empty variables object for future extensibility

## Implementation Details
The configuration follows the established pattern for CLI tool telemetry settings, clearly documenting that React Native Windows telemetry cannot be disabled through environment variables and must be controlled via command-line flags instead.

https://claude.ai/code/session_01PbGMJgwpXNF3rXnFnkHPae