### PR TITLE
Add Vue CLI tool configuration

### DIFF
--- a/tools/_vue.nix
+++ b/tools/_vue.nix
@@ -1,8 +1,5 @@
 # No environment variable telemetry opt-out available.
 # Vue CLI (@vue/cli) and create-vue do not appear to collect telemetry data.
-# Unlike frameworks like Next.js or Nuxt, Vue CLI has no documented telemetry
-# collection or opt-out mechanism. The Vue ecosystem relies on Nuxt for
-# telemetry collection, which has its own separate opt-out variable.
 {
   name = "vue";
   meta = {


### PR DESCRIPTION
## Summary
Added a new tool configuration file for Vue.js CLI tooling to the tools directory.

## Changes
- Created `tools/_vue.nix` with metadata and configuration for Vue CLI (@vue/cli) and create-vue
- Includes tool description, homepage, and documentation links
- Documents that no telemetry opt-out environment variables are available, as Vue CLI does not appear to collect telemetry data
- Defines empty variables object as no environment configuration is needed

## Implementation Details
The configuration follows the standard tool definition pattern with:
- Tool name: "vue"
- Metadata including description, homepage, and documentation URL pointing to the official Vue CLI guide
- Empty variables section since no telemetry or environment variables require configuration

https://claude.ai/code/session_01TmihPY3YNjaCCcSpX1tE96