### PR TITLE
Add CI linting, dependabot, and add-tool skill

### DIFF
--- a/.claude/skills/add-tool/SKILL.md
+++ b/.claude/skills/add-tool/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: add-tool
+description: Investigate a tool from a GitHub issue and add it to the opt-out flake
+---
+
+# Add tool
+
+Investigate the tool described in GitHub issue $ARGUMENTS and determine whether it qualifies for the opt-out flake.
+
+1. **Read the GitHub issue** using `gh issue view` to get the tool name and any linked documentation.
+
+2. **Research the tool** by visiting its official documentation and source repository. Look specifically for environment variables that disable telemetry, analytics, or crash reporting.
+
+3. **Verify eligibility.** Only environment variable opt-outs qualify. The following do NOT qualify:
+   - Update check suppression (e.g., `DENO_NO_UPDATE_CHECK`)
+   - CLI-command-based opt-out (e.g., `flutter --disable-analytics`)
+   - Settings-file-based opt-out
+
+4. **Check for duplicates.** Verify the tool does not already exist in `tools/` (including `_`-prefixed excluded files).
+
+5. **Create the tool file:**
+
+   **If a valid env var opt-out exists**, create `tools/<toolname>.nix`:
+
+   ```nix
+   {
+     name = "<toolname>";
+     meta = {
+       description = "<description of the tool itself — do not reference other tools>";
+       homepage = "<link to the tool's git repository>";
+       documentation = "<link to the specific documentation page proving the env var opt-out>";
+     };
+     variables = {
+       ENV_VAR_NAME = "value";
+     };
+   }
+   ```
+
+   **If NO valid env var opt-out exists**, create `tools/_<toolname>.nix`:
+
+   ```nix
+   # Not supported via environment variable.
+   # <Explain why: e.g., "Opt-out requires CLI: tool --disable-analytics">
+   {
+     name = "<toolname>";
+     meta = {
+       description = "<description of the tool itself — do not reference other tools>";
+       homepage = "<link to the tool's git repository>";
+       documentation = "<link to relevant documentation>";
+     };
+     variables = { };
+   }
+   ```
+
+6. **Metadata rules:**
+   - The `description` must describe only the tool being added. Do not mention other tools, frameworks, or ecosystems.
+   - The `homepage` must link to the tool's own repository.
+   - The `documentation` must link to the tool's own documentation page that covers telemetry/analytics opt-out.
+
+7. **Stage, format, and validate:**
+
+   ```bash
+   git add tools/<filename>.nix
+   mise run fmt
+   mise run lint
+   mise run flake-check
+   ```
+
+8. **Update README if the tool was added (not `_`-prefixed):**
+
+   ```bash
+   mise run readme-vars
+   git add README.md
+   ```
+
+9. **Commit, push, and create a PR:**
+   - Create a branch named `add-tool/<toolname>`
+   - Commit with a clear message describing the addition
+   - Push and create a PR using `gh pr create`
+   - **Assign the PR to `@adampie`**
+   - **Link to the GitHub issue in the PR body:**
+     - Use `Closes #<number>` if the tool was added (valid env var opt-out found)
+     - Use `Relates to #<number>` if the tool was excluded (`_`-prefixed), since the issue is not resolved

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - "adampie"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,58 @@
+---
+name: "Lint"
+"on":
+  pull_request:
+    branches:
+      - "main"
+jobs:
+  flake-check:
+    name: "Flake check"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v6"
+      - uses: "DeterminateSystems/determinate-nix-action@v3"
+      - uses: "DeterminateSystems/magic-nix-cache-action@main"
+      - run: "nix flake check"
+
+  lint-nix:
+    name: "Lint and format Nix"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v6"
+      - uses: "DeterminateSystems/determinate-nix-action@v3"
+      - uses: "DeterminateSystems/magic-nix-cache-action@main"
+      - run: |
+          nix-shell -p statix deadnix nixfmt-rfc-style \
+            --run 'statix check . && deadnix . && nixfmt --check .'
+
+  lint-shell:
+    name: "Lint shell scripts"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v6"
+      - uses: "DeterminateSystems/determinate-nix-action@v3"
+      - uses: "DeterminateSystems/magic-nix-cache-action@main"
+      - run: |
+          nix-shell -p shellcheck shfmt \
+            --run 'shellcheck scripts/*.sh && shfmt -d scripts/*.sh'
+
+  lint-markdown:
+    name: "Lint Markdown"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v6"
+      - uses: "actions/setup-node@v4"
+        with:
+          node-version: "22"
+      - run: "npx markdownlint-cli2 '**/*.md'"
+
+  lint-yaml-toml:
+    name: "Lint YAML and TOML"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v6"
+      - uses: "DeterminateSystems/determinate-nix-action@v3"
+      - uses: "DeterminateSystems/magic-nix-cache-action@main"
+      - run: |
+          nix-shell -p yamllint taplo \
+            --run 'yamllint . && taplo check'

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,19 @@
+---
+name: "Update flake inputs"
+"on":
+  schedule:
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+jobs:
+  update-flake-lock:
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: "write"
+      pull-requests: "write"
+    steps:
+      - uses: "actions/checkout@v6"
+      - uses: "DeterminateSystems/determinate-nix-action@v3"
+      - uses: "DeterminateSystems/update-flake-lock@main"
+        with:
+          pr-title: "Update flake inputs"
+          pr-assignees: "adampie"


### PR DESCRIPTION
## Summary

- Add **lint workflow** on PRs: flake check, nix lint/format (statix, deadnix, nixfmt), shell (shellcheck, shfmt), markdown, yaml, and toml linting with magic-nix-cache
- Add **dependabot** for GitHub Actions version updates (weekly, assigned to @adampie)
- Add **update-flake-lock** scheduled workflow to keep flake inputs current (weekly, opens PR assigned to @adampie)
- Add **`.claude/skills/add-tool`** slash command for investigating tools from GitHub issues and creating PRs

## Test plan

- [ ] Verify lint workflow triggers on PRs to main
- [ ] Verify dependabot opens PRs for action updates
- [ ] Verify update-flake-lock runs on schedule or manual dispatch
- [ ] Test `/add-tool` skill with a GitHub issue number