### PR TITLE
Add path-based filtering to CI workflows

### DIFF
--- a/.github/workflows/flakehub-publish-rolling.yml
+++ b/.github/workflows/flakehub-publish-rolling.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - "main"
+    paths:
+      - "**/*.nix"
+      - "flake.lock"
 jobs:
   flakehub-publish:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,8 +5,39 @@ name: "Lint"
     branches:
       - "main"
 jobs:
+  detect-changes:
+    name: "Detect changes"
+    runs-on: "ubuntu-latest"
+    permissions:
+      pull-requests: "read"
+    outputs:
+      nix: ${{ steps.filter.outputs.nix }}
+      shell: ${{ steps.filter.outputs.shell }}
+      markdown: ${{ steps.filter.outputs.markdown }}
+      yaml-toml: ${{ steps.filter.outputs.yaml-toml }}
+    steps:
+      - uses: "actions/checkout@v6"
+      - uses: "dorny/paths-filter@v3"
+        id: "filter"
+        with:
+          filters: |
+            nix:
+              - '**/*.nix'
+              - 'flake.lock'
+            shell:
+              - '**/*.sh'
+            markdown:
+              - '**/*.md'
+              - '.markdownlint*'
+            yaml-toml:
+              - '**/*.yml'
+              - '**/*.yaml'
+              - '**/*.toml'
+
   flake-check:
     name: "Flake check"
+    needs: "detect-changes"
+    if: ${{ needs.detect-changes.outputs.nix == 'true' }}
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v6"
@@ -16,6 +47,8 @@ jobs:
 
   lint-nix:
     name: "Lint and format Nix"
+    needs: "detect-changes"
+    if: ${{ needs.detect-changes.outputs.nix == 'true' }}
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v6"
@@ -27,6 +60,8 @@ jobs:
 
   lint-shell:
     name: "Lint shell scripts"
+    needs: "detect-changes"
+    if: ${{ needs.detect-changes.outputs.shell == 'true' }}
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v6"
@@ -38,6 +73,8 @@ jobs:
 
   lint-markdown:
     name: "Lint Markdown"
+    needs: "detect-changes"
+    if: ${{ needs.detect-changes.outputs.markdown == 'true' }}
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v6"
@@ -48,6 +85,8 @@ jobs:
 
   lint-yaml-toml:
     name: "Lint YAML and TOML"
+    needs: "detect-changes"
+    if: ${{ needs.detect-changes.outputs.yaml-toml == 'true' }}
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v6"


### PR DESCRIPTION
## Summary

- Added a new `detect-changes` job to the lint workflow that uses `dorny/paths-filter` to detect which file types have changed
- Updated all lint jobs (`flake-check`, `lint-nix`, `lint-shell`, `lint-markdown`, `lint-yaml-toml`) to conditionally run only when their respective file types are modified
- Added path filtering to the `flakehub-publish-rolling` workflow to only trigger on Nix file changes

This optimization prevents unnecessary CI job execution when only unrelated files are modified, improving workflow efficiency and reducing resource usage.

## Related Issue

Closes https://github.com/adampie/opt-out/issues/11

https://claude.ai/code/session_01CSaPZEmarJQfpgCoedXxX1