### PR TITLE
Add permissions block to lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,8 @@ name: "Lint"
   pull_request:
     branches:
       - "main"
+permissions:
+  contents: "read"
 jobs:
   flake-check:
     name: "Flake check"


### PR DESCRIPTION
## Summary

- Add top-level `permissions: { contents: read }` to the lint workflow, restricting `GITHUB_TOKEN` to read-only access for all jobs
- Follows the principle of least privilege, consistent with the other workflows in this repo

Resolves code scanning alerts 6, 7, 8, 9, 10 (`actions/missing-workflow-permissions`).

## Test plan

- [ ] Verify the lint workflow still passes on this PR