### PR TITLE
Add colorama to tools metadata with telemetry verification

### DIFF
--- a/tools/_colorama.nix
+++ b/tools/_colorama.nix
@@ -1,0 +1,14 @@
+# No telemetry, analytics, or crash reporting.
+# Colorama is a pure utility library with no data collection.
+{
+  name = "colorama";
+  meta = {
+    description = "Cross-platform colored terminal text for Python";
+    homepage = "https://github.com/tartley/colorama";
+    documentation = "https://github.com/tartley/colorama#readme";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}


### PR DESCRIPTION
## Summary

- Added `tools/_colorama.nix` metadata file documenting the colorama Python library
- Verified and documented that colorama has no telemetry, analytics, or crash reporting
- Included library description, homepage, documentation links, and last verification date

## Related Issue

Closes #

https://claude.ai/code/session_01U32Xn2NXMXqCqz86iSZgtj