### PR TITLE
Add colorama to telemetry audit database

### DIFF
--- a/tools/_colorama.nix
+++ b/tools/_colorama.nix
@@ -1,0 +1,14 @@
+# No telemetry to opt out of.
+# Colorama is a simple library for colored terminal text output with no analytics or data collection.
+{
+  name = "colorama";
+  meta = {
+    description = "Cross-platform colored terminal text";
+    homepage = "https://github.com/tartley/colorama";
+    documentation = "https://github.com/tartley/colorama#description";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}


### PR DESCRIPTION
## Summary

- Added `tools/_colorama.nix` to document that colorama has no telemetry
- Colorama is a simple cross-platform library for colored terminal text with no analytics or data collection
- Marked `hasTelemetry` as `false` in the metadata

## Related Issue

Closes #

https://claude.ai/code/session_012Uo3bqs2v9o7eJXkxAsc3N