### PR TITLE
Add markdownlint-cli2 tool configuration

### DIFF
--- a/tools/_markdownlint-cli2.nix
+++ b/tools/_markdownlint-cli2.nix
@@ -1,0 +1,12 @@
+{
+  name = "markdownlint-cli2";
+  meta = {
+    description = "A fast, flexible, configuration-based command-line interface for linting Markdown files";
+    homepage = "https://github.com/DavidAnson/markdownlint-cli2";
+    documentation = "https://github.com/DavidAnson/markdownlint-cli2#readme";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}


### PR DESCRIPTION
## Summary

- Added Nix configuration file for markdownlint-cli2, a command-line linter for Markdown files
- Includes tool metadata with description, homepage, documentation link, and telemetry information
- Provides baseline configuration structure for the tool integration

## Related Issue

Closes #30 

https://claude.ai/code/session_01NuFbFKohFTHn83AoggLKR8