### PR TITLE
Add Node.js tool definition to tools directory

### DIFF
--- a/tools/_nodejs.nix
+++ b/tools/_nodejs.nix
@@ -1,0 +1,16 @@
+{
+  name = "nodejs";
+  meta = {
+    description = "Node.js JavaScript runtime";
+    homepage = "https://github.com/nodejs/node";
+    documentation = "https://nodejs.org/api/cli.html";
+    lastChecked = "2026-03-14";
+    # Node.js core does not collect any telemetry, analytics, or crash reports.
+    # This was confirmed by reviewing the CLI documentation and GitHub repository.
+    # Note: frameworks built on Node.js (e.g., Next.js, Gatsby) may have their own
+    # telemetry, but those are separate tools with their own opt-out mechanisms.
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}


### PR DESCRIPTION
## Summary

- Added a new tool definition file for Node.js (`tools/_nodejs.nix`)
- Includes metadata documenting that Node.js core does not collect telemetry
- Provides structured information about the Node.js runtime including homepage, documentation, and last checked date
- Notes that while Node.js itself has no telemetry, frameworks built on it may have their own separate mechanisms

## Related Issue

Closes #31 

https://claude.ai/code/session_015q3rdm7VxsLB4YqAKn3Qob