### PR TITLE
Add gotestsum to telemetry allowlist

### DIFF
--- a/tools/_gotestsum.nix
+++ b/tools/_gotestsum.nix
@@ -1,0 +1,11 @@
+# No telemetry to opt out of.
+# gotestsum is a test runner with no analytics, telemetry, or crash reporting features.
+{
+  name = "gotestsum";
+  meta = {
+    description = "Go test runner with formatted output and test summaries";
+    homepage = "https://github.com/gotestyourself/gotestsum";
+    documentation = "https://pkg.go.dev/gotest.tools/gotestsum";
+  };
+  variables = { };
+}


### PR DESCRIPTION
## Summary

- Added `tools/_gotestsum.nix` configuration file to the telemetry allowlist
- Documented that gotestsum has no telemetry, analytics, or crash reporting features
- Included metadata with description, homepage, and documentation links

## Related Issue

Closes #26 

https://claude.ai/code/session_01KbgAWNWeHY3xhfzmUw9pKy