### PR TITLE
Add hk tool telemetry metadata

### DIFF
--- a/tools/_hk.nix
+++ b/tools/_hk.nix
@@ -1,0 +1,14 @@
+# No telemetry features found.
+# hk does not collect analytics, telemetry, or crash reports.
+{
+  name = "hk";
+  meta = {
+    description = "Git hook manager and project linting tool";
+    homepage = "https://github.com/jdx/hk";
+    documentation = "https://github.com/jdx/hk/blob/main/docs/environment_variables.md";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}


### PR DESCRIPTION
## Summary

- Added telemetry metadata for the `hk` Git hook manager tool
- Documented that hk does not collect analytics, telemetry, or crash reports
- Included tool description, homepage, and documentation links

## Related Issue

Closes #28 

https://claude.ai/code/session_017vRJqaDsbrqaKfmPyuNVTE