### PR TITLE
Add golangci-lint telemetry metadata

### DIFF
--- a/tools/_golangci-lint.nix
+++ b/tools/_golangci-lint.nix
@@ -1,0 +1,14 @@
+# No telemetry found.
+# golangci-lint does not collect telemetry or analytics data.
+{
+  name = "golangci-lint";
+  meta = {
+    description = "Fast linters runner for Go";
+    homepage = "https://github.com/golangci/golangci-lint";
+    documentation = "https://golangci-lint.run/";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}


### PR DESCRIPTION
## Summary

- Added telemetry metadata file for golangci-lint tool
- Documented that golangci-lint does not collect telemetry or analytics data
- Included tool description, homepage, and documentation links

## Related Issue

Closes #23 

https://claude.ai/code/session_01P6A8ARUx9sA3VJUN6A3tmt