### PR TITLE
Add taplo TOML toolkit to tools

### DIFF
--- a/tools/_taplo.nix
+++ b/tools/_taplo.nix
@@ -1,0 +1,12 @@
+{
+  name = "taplo";
+  meta = {
+    description = "TOML toolkit (formatter, linter, LSP)";
+    homepage = "https://github.com/tamasfe/taplo";
+    documentation = "https://taplo.tamasfe.dev/";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}


### PR DESCRIPTION
## Summary

- Added `tools/_taplo.nix` configuration file for the taplo TOML toolkit
- Includes metadata with description, homepage, documentation link, and telemetry information
- Provides tool definition with empty variables and commands sections for future expansion

## Related Issue

Closes #36 

https://claude.ai/code/session_01ARipky3XZpDhXGaixzX3sc