### PR TITLE
Exclude yamllint: no telemetry found

### DIFF
--- a/tools/_yamllint.nix
+++ b/tools/_yamllint.nix
@@ -1,0 +1,12 @@
+{
+  name = "yamllint";
+  meta = {
+    description = "A linter for YAML files that checks for syntax errors, key repetition, and cosmetic issues.";
+    homepage = "https://github.com/adrienverge/yamllint";
+    documentation = "https://yamllint.readthedocs.io/en/stable/";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}


### PR DESCRIPTION
## Summary
- Investigated yamllint for telemetry opt-out environment variables
- yamllint has no telemetry or analytics whatsoever — it is a straightforward YAML linter
- Created `tools/_yamllint.nix` as an excluded tool with `hasTelemetry = false`

Closes #139