### PR TITLE
Exclude deadnix: no telemetry found

### DIFF
--- a/tools/_deadnix.nix
+++ b/tools/_deadnix.nix
@@ -1,0 +1,12 @@
+{
+  name = "deadnix";
+  meta = {
+    description = "Static analysis tool that scans Nix files for unused code and dead bindings.";
+    homepage = "https://github.com/astro/deadnix";
+    documentation = "https://github.com/astro/deadnix";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}


### PR DESCRIPTION
## Summary
- Investigated deadnix for telemetry opt-out environment variables
- deadnix is a static Nix dead-code scanner with no telemetry, analytics, or crash reporting
- Added as an excluded tool (`tools/_deadnix.nix`) with `hasTelemetry = false`

Closes #132