### PR TITLE
Exclude import-tree tool (no telemetry)

### DIFF
--- a/tools/_import-tree.nix
+++ b/tools/_import-tree.nix
@@ -1,0 +1,12 @@
+{
+  name = "import-tree";
+  meta = {
+    description = "A Nix library that recursively imports all .nix files from a directory tree into a single module.";
+    homepage = "https://github.com/vic/import-tree";
+    documentation = "https://github.com/vic/import-tree";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}


### PR DESCRIPTION
## Summary
- Investigated import-tree for telemetry opt-out environment variables
- import-tree is a pure Nix library that recursively imports `.nix` files from a directory tree — it has no executable binary, no network calls, and no telemetry of its own
- Added as `tools/_import-tree.nix` with `hasTelemetry = false`

Closes #127