### PR TITLE
Exclude nixd: no telemetry environment variables

### DIFF
--- a/tools/_nixd.nix
+++ b/tools/_nixd.nix
@@ -1,0 +1,12 @@
+{
+  name = "nixd";
+  meta = {
+    description = "Nix language server with rich IDE features powered by Nix libraries";
+    homepage = "https://github.com/nix-community/nixd";
+    documentation = "https://github.com/nix-community/nixd";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}


### PR DESCRIPTION
## Summary

- Investigated nixd (Nix language server) for telemetry opt-out environment variables
- Reviewed the full source code at https://github.com/nix-community/nixd
- nixd has no telemetry, analytics, or crash reporting functionality — confirmed by searching all source files
- Created `tools/_nixd.nix` with `hasTelemetry = false` to document the investigation

Closes #135