### PR TITLE
Exclude nil: no telemetry found

### DIFF
--- a/tools/_nil.nix
+++ b/tools/_nil.nix
@@ -1,0 +1,12 @@
+{
+  name = "nil";
+  meta = {
+    description = "Incremental analysis assistant and language server for the Nix language.";
+    homepage = "https://github.com/oxalica/nil";
+    documentation = "https://github.com/oxalica/nil/blob/main/docs/configuration.md";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}


### PR DESCRIPTION
## Summary

- Investigated nil (Nix LSP) for telemetry opt-out environment variables
- Confirmed nil has no telemetry, analytics, or crash reporting whatsoever
- Added as excluded tool (`_nil.nix`) with `hasTelemetry = false`

## Research

- Searched the full source codebase for telemetry/analytics code — none found
- Reviewed `docs/configuration.md` — only LSP configuration options, no telemetry
- nil is a pure language server with no data collection

Closes #134