### PR TITLE
Exclude nixpkgs tool — no telemetry

### DIFF
--- a/tools/_nixpkgs.nix
+++ b/tools/_nixpkgs.nix
@@ -1,0 +1,12 @@
+{
+  name = "nixpkgs";
+  meta = {
+    description = "Nix Packages collection — a set of over 100,000 software packages for the Nix package manager";
+    homepage = "https://github.com/NixOS/nixpkgs";
+    documentation = "https://github.com/NixOS/nixpkgs";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}


### PR DESCRIPTION
## Summary

- Investigated nixpkgs for telemetry opt-out environment variables
- nixpkgs is a package collection/repository, not a tool that collects data itself
- No telemetry exists; added as an excluded file (`tools/_nixpkgs.nix`) with `hasTelemetry = false`

Closes #130