### PR TITLE
Exclude flake-parts: no telemetry found

### DIFF
--- a/tools/_alejandra.nix
+++ b/tools/_alejandra.nix
@@ -1,0 +1,12 @@
+{
+  name = "alejandra";
+  meta = {
+    description = "Nix code formatter focused on an opinionated, consistent style.";
+    homepage = "https://github.com/kamadorueda/alejandra";
+    documentation = "https://github.com/kamadorueda/alejandra";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}

--- a/tools/_deadnix.nix
+++ b/tools/_deadnix.nix
@@ -1,0 +1,12 @@
+{
+  name = "deadnix";
+  meta = {
+    description = "Static analysis tool that scans Nix files for unused code and dead bindings.";
+    homepage = "https://github.com/astro/deadnix";
+    documentation = "https://github.com/astro/deadnix";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}

--- a/tools/_flake-parts.nix
+++ b/tools/_flake-parts.nix
@@ -1,0 +1,12 @@
+{
+  name = "flake-parts";
+  meta = {
+    description = "A framework for writing Nix Flakes using the module system.";
+    homepage = "https://github.com/hercules-ci/flake-parts";
+    documentation = "https://flake.parts";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}

--- a/tools/_home-manager.nix
+++ b/tools/_home-manager.nix
@@ -1,0 +1,12 @@
+{
+  name = "home-manager";
+  meta = {
+    description = "A system for managing a user environment using the Nix package manager, enabling declarative configuration of user-specific packages and dotfiles.";
+    homepage = "https://github.com/nix-community/home-manager";
+    documentation = "https://nix-community.github.io/home-manager/";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}

--- a/tools/_import-tree.nix
+++ b/tools/_import-tree.nix
@@ -1,0 +1,12 @@
+{
+  name = "import-tree";
+  meta = {
+    description = "A Nix library that recursively imports all .nix files from a directory tree into a single module.";
+    homepage = "https://github.com/vic/import-tree";
+    documentation = "https://github.com/vic/import-tree";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}

--- a/tools/_nil.nix
+++ b/tools/_nil.nix
@@ -1,0 +1,12 @@
+{
+  name = "nil";
+  meta = {
+    description = "Incremental analysis assistant and language server for the Nix language.";
+    homepage = "https://github.com/oxalica/nil";
+    documentation = "https://github.com/oxalica/nil/blob/main/docs/configuration.md";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}

--- a/tools/_nix-darwin.nix
+++ b/tools/_nix-darwin.nix
@@ -1,0 +1,12 @@
+{
+  name = "nix-darwin";
+  meta = {
+    description = "Nix modules for macOS, allowing declarative system configuration similar to NixOS.";
+    homepage = "https://github.com/nix-darwin/nix-darwin";
+    documentation = "https://nix-darwin.github.io/nix-darwin/manual/";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}

--- a/tools/_nixd.nix
+++ b/tools/_nixd.nix
@@ -1,0 +1,12 @@
+{
+  name = "nixd";
+  meta = {
+    description = "Nix language server with rich IDE features powered by Nix libraries";
+    homepage = "https://github.com/nix-community/nixd";
+    documentation = "https://github.com/nix-community/nixd";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}

--- a/tools/_nixfmt-rfc-style.nix
+++ b/tools/_nixfmt-rfc-style.nix
@@ -1,0 +1,12 @@
+{
+  name = "nixfmt-rfc-style";
+  meta = {
+    description = "The official formatter for Nix code, implementing the standard Nix format.";
+    homepage = "https://github.com/NixOS/nixfmt";
+    documentation = "https://github.com/NixOS/nixfmt/blob/master/README.md";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}

--- a/tools/_nixos-generators.nix
+++ b/tools/_nixos-generators.nix
@@ -1,0 +1,12 @@
+{
+  name = "nixos-generators";
+  meta = {
+    description = "Collection of image builders for NixOS, supporting formats like ISO, qcow2, Amazon EC2, Azure, GCE, and more.";
+    homepage = "https://github.com/nix-community/nixos-generators";
+    documentation = "https://github.com/nix-community/nixos-generators";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}

--- a/tools/_nixpkgs-fmt.nix
+++ b/tools/_nixpkgs-fmt.nix
@@ -1,0 +1,12 @@
+{
+  name = "nixpkgs-fmt";
+  meta = {
+    description = "Nix code formatter for nixpkgs (archived, replaced by nixfmt)";
+    homepage = "https://github.com/nix-community/nixpkgs-fmt";
+    documentation = "https://github.com/nix-community/nixpkgs-fmt";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}

--- a/tools/_nixpkgs.nix
+++ b/tools/_nixpkgs.nix
@@ -1,0 +1,12 @@
+{
+  name = "nixpkgs";
+  meta = {
+    description = "Nix Packages collection — a set of over 100,000 software packages for the Nix package manager";
+    homepage = "https://github.com/NixOS/nixpkgs";
+    documentation = "https://github.com/NixOS/nixpkgs";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}

--- a/tools/_statix.nix
+++ b/tools/_statix.nix
@@ -1,0 +1,12 @@
+{
+  name = "statix";
+  meta = {
+    description = "Linter and suggestions tool for the Nix programming language";
+    homepage = "https://github.com/oppiliappan/statix";
+    documentation = "https://github.com/oppiliappan/statix";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}

--- a/tools/_yamllint.nix
+++ b/tools/_yamllint.nix
@@ -1,0 +1,12 @@
+{
+  name = "yamllint";
+  meta = {
+    description = "A linter for YAML files that checks for syntax errors, key repetition, and cosmetic issues.";
+    homepage = "https://github.com/adrienverge/yamllint";
+    documentation = "https://yamllint.readthedocs.io/en/stable/";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}


### PR DESCRIPTION
## Summary
- Investigated flake-parts for telemetry opt-out environment variables
- Confirmed flake-parts has no telemetry, analytics, or crash reporting
- Added as excluded tool (`tools/_flake-parts.nix`) with `hasTelemetry = false`

flake-parts is a pure Nix module system framework. It has no executable binary, makes no network calls for telemetry purposes, and has no data collection mechanisms.

Closes #125