### PR TITLE
Exclude nixpkgs-fmt: no telemetry found

### DIFF
--- a/tools/_nixpkgs-fmt.nix
+++ b/tools/_nixpkgs-fmt.nix
@@ -1,0 +1,12 @@
+{
+  name = "nixpkgs-fmt";
+  meta = {
+    description = "Nix code formatter for nixpkgs (archived, replaced by nixfmt)";
+    homepage = "https://github.com/nix-community/nixpkgs-fmt";
+    documentation = "https://github.com/nix-community/nixpkgs-fmt";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}


### PR DESCRIPTION
## Summary

- Investigated nixpkgs-fmt for telemetry opt-out environment variables
- nixpkgs-fmt is an archived Nix code formatter (replaced by nixfmt) with no telemetry, analytics, or crash reporting
- Confirmed `hasTelemetry = false` after reviewing source code in the repository
- Added as excluded tool `tools/_nixpkgs-fmt.nix`

Closes #137