### PR TITLE
Exclude nixos-generators tool (no telemetry found)

### DIFF
--- a/tools/_nixos-generators.nix
+++ b/tools/_nixos-generators.nix
@@ -1,0 +1,12 @@
+{
+  name = "nixos-generators";
+  meta = {
+    description = "Collection of image builders for NixOS, supporting formats like ISO, qcow2, Amazon EC2, Azure, GCE, and more.";
+    homepage = "https://github.com/nix-community/nixos-generators";
+    documentation = "https://github.com/nix-community/nixos-generators";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}


### PR DESCRIPTION
## Summary

- Investigated nixos-generators for telemetry opt-out environment variables
- No telemetry or analytics found in the codebase or documentation
- The project has been deprecated in favor of `nixos-rebuild build-image` (upstreamed into nixpkgs in NixOS 25.05)
- Added as an excluded tool (`tools/_nixos-generators.nix`) with `hasTelemetry = false`

Closes #129