### PR TITLE
Exclude home-manager: no telemetry found

### DIFF
--- a/tools/_home-manager.nix
+++ b/tools/_home-manager.nix
@@ -1,0 +1,12 @@
+{
+  name = "home-manager";
+  meta = {
+    description = "A system for managing a user environment using the Nix package manager, enabling declarative configuration of user-specific packages and dotfiles.";
+    homepage = "https://github.com/nix-community/home-manager";
+    documentation = "https://nix-community.github.io/home-manager/";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}


### PR DESCRIPTION
## Summary
- Investigated home-manager for telemetry opt-out environment variables
- home-manager has no telemetry, analytics, or crash reporting — it is a pure Nix community tool with no data collection
- Added as an excluded tool (`tools/_home-manager.nix`) with `hasTelemetry = false`

Closes #126