### PR TITLE
Exclude nix-darwin: no telemetry found

### DIFF
--- a/tools/_nix-darwin.nix
+++ b/tools/_nix-darwin.nix
@@ -1,0 +1,12 @@
+{
+  name = "nix-darwin";
+  meta = {
+    description = "Nix modules for macOS, allowing declarative system configuration similar to NixOS.";
+    homepage = "https://github.com/nix-darwin/nix-darwin";
+    documentation = "https://nix-darwin.github.io/nix-darwin/manual/";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}


### PR DESCRIPTION
## Summary

- Investigated nix-darwin for telemetry opt-out environment variables
- No telemetry, analytics, or crash reporting was found in the nix-darwin project
- Created `tools/_nix-darwin.nix` as an excluded tool with `hasTelemetry = false`

## Research findings

Searched the nix-darwin repository and documentation thoroughly. nix-darwin is a pure configuration management tool with no data collection mechanisms. No environment variables for telemetry opt-out exist because there is no telemetry to opt out of.

Closes #128