### PR TITLE
Exclude nixfmt-rfc-style: no telemetry found

### DIFF
--- a/tools/_nixfmt-rfc-style.nix
+++ b/tools/_nixfmt-rfc-style.nix
@@ -1,0 +1,12 @@
+{
+  name = "nixfmt-rfc-style";
+  meta = {
+    description = "The official formatter for Nix code, implementing the standard Nix format.";
+    homepage = "https://github.com/NixOS/nixfmt";
+    documentation = "https://github.com/NixOS/nixfmt/blob/master/README.md";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}


### PR DESCRIPTION
## Summary
- Investigated nixfmt-rfc-style for telemetry opt-out environment variables
- nixfmt is a pure Nix code formatter with no telemetry, analytics, or crash reporting
- No environment variable opt-out exists — excluded with `_` prefix and `hasTelemetry = false`

Closes #136