### PR TITLE
Exclude alejandra: no telemetry

### DIFF
--- a/tools/_alejandra.nix
+++ b/tools/_alejandra.nix
@@ -1,0 +1,12 @@
+{
+  name = "alejandra";
+  meta = {
+    description = "Nix code formatter focused on an opinionated, consistent style.";
+    homepage = "https://github.com/kamadorueda/alejandra";
+    documentation = "https://github.com/kamadorueda/alejandra";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}


### PR DESCRIPTION
## Summary

- Investigated alejandra (https://github.com/kamadorueda/alejandra) for telemetry opt-out environment variables
- Confirmed alejandra has no telemetry, analytics, or crash reporting — `hasTelemetry = false`
- The tool displays local sponsor/contributor thank-you messages in terminal output, but collects no data and makes no network calls
- Added as excluded tool `tools/_alejandra.nix`

Closes #131