### PR TITLE
Exclude statix: no telemetry found

### DIFF
--- a/tools/_statix.nix
+++ b/tools/_statix.nix
@@ -1,0 +1,12 @@
+{
+  name = "statix";
+  meta = {
+    description = "Linter and suggestions tool for the Nix programming language";
+    homepage = "https://github.com/oppiliappan/statix";
+    documentation = "https://github.com/oppiliappan/statix";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+}


### PR DESCRIPTION
## Summary
- Investigated statix for telemetry opt-out environment variables
- statix is a Nix linting and suggestions tool with no telemetry, analytics, or crash reporting
- Created `tools/_statix.nix` as an excluded tool with `hasTelemetry = false`

Closes #138