### PR TITLE
Exclude codex: config-file-based opt-out only

### DIFF
--- a/tools/_codex.nix
+++ b/tools/_codex.nix
@@ -1,0 +1,17 @@
+{
+  name = "codex";
+  meta = {
+    description = "Lightweight coding agent that runs in the terminal";
+    homepage = "https://github.com/openai/codex";
+    documentation = "https://developers.openai.com/codex/config-reference";
+    lastChecked = "2026-03-14";
+    hasTelemetry = true;
+  };
+  variables = { };
+  commands = { };
+  config = {
+    "~/.codex/config.toml" = {
+      "analytics.enabled" = "false";
+    };
+  };
+}


### PR DESCRIPTION
## Summary

- Investigated Codex CLI (OpenAI's terminal-based coding agent) for telemetry opt-out
- Telemetry exists (analytics events and OpenTelemetry metrics) but opt-out is config-file-based only (`analytics.enabled = false` in `~/.codex/config.toml`)
- No environment variable opt-out — added as excluded tool (`_codex.nix`)

Closes #239

## Test plan

- [x] `mise run fmt` passes
- [x] `mise run lint` passes
- [x] `mise run flake-check` passes
- [x] File is `_`-prefixed so it's excluded from flake outputs