### PR TITLE
Exclude zed: settings-file-based opt-out only

### DIFF
--- a/tools/_zed.nix
+++ b/tools/_zed.nix
@@ -1,0 +1,18 @@
+{
+  name = "zed";
+  meta = {
+    description = "High-performance, multiplayer code editor";
+    homepage = "https://github.com/zed-industries/zed";
+    documentation = "https://zed.dev/docs/telemetry";
+    lastChecked = "2026-03-14";
+    hasTelemetry = true;
+  };
+  variables = { };
+  commands = { };
+  config = {
+    "~/.config/zed/settings.json" = {
+      "telemetry.diagnostics" = "false";
+      "telemetry.metrics" = "false";
+    };
+  };
+}


### PR DESCRIPTION
## Summary

- Investigated Zed editor for telemetry opt-out
- Telemetry exists (diagnostics and metrics) but opt-out is settings-file-based only (`telemetry.diagnostics` and `telemetry.metrics` in `settings.json`)
- No environment variable opt-out — added as excluded tool (`_zed.nix`)

Closes #238

## Test plan

- [x] `mise run fmt` passes
- [x] `mise run lint` passes
- [x] `mise run flake-check` passes
- [x] File is `_`-prefixed so it's excluded from flake outputs