### PR TITLE
Update add-tool skill to always use Closes for issue linking

### DIFF
--- a/.claude/skills/add-tool/SKILL.md
+++ b/.claude/skills/add-tool/SKILL.md
@@ -106,6 +106,4 @@ Investigate the tool described in GitHub issue $ARGUMENTS and determine whether 
    - Commit with a clear message describing the addition
    - Push and create a PR using `gh pr create`
    - **Assign the PR to `@adampie`**
-   - **Link to the GitHub issue in the PR body:**
-     - Use `Closes #<number>` if the tool was added (valid env var opt-out found)
-     - Use `Relates to #<number>` if the tool was excluded (`_`-prefixed), since the issue is not resolved
+   - **Link to the GitHub issue in the PR body** with `Closes #<number>`


### PR DESCRIPTION
## Summary

- Previously the skill used `Closes #` for active tools and `Relates to #` for excluded tools
- Now always uses `Closes #` since investigating a tool completes the issue regardless of outcome

## Test plan

- [x] Skill file is valid markdown