### PR TITLE
Add Homebrew tool investigations and schema validation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,6 +38,19 @@ jobs:
               - '**/*.yaml'
               - '**/*.toml'
 
+  validate-tools:
+    name: "Validate tool schemas"
+    needs: "detect-changes"
+    if: ${{ needs.detect-changes.outputs.nix == 'true' }}
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6
+        with:
+          persist-credentials: false
+      - uses: "DeterminateSystems/determinate-nix-action@131015bad844610e5e6300f8a143bf625d3e74f4" # v3
+      - uses: "DeterminateSystems/magic-nix-cache-action@cec65ff6f104850203b152861d3f9e5f1747885d" # main
+      - run: "nix eval .#validateAll > /dev/null"
+
   flake-check:
     name: "Flake check"
     needs: "detect-changes"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,67 @@
         let
           inherit (inputs.flake-parts.inputs.nixpkgs-lib) lib;
           toolFiles = ((inputs.import-tree.addPath ./tools).withLib lib).files;
-          toolDefs = map import toolFiles;
+
+          validateTool =
+            file: t:
+            let
+              fileName = builtins.baseNameOf (builtins.toString file);
+              has = attr: builtins.hasAttr attr t;
+              hasMeta = attr: builtins.hasAttr attr (t.meta or { });
+              isString = v: builtins.isString v;
+              isBool = v: builtins.isBool v;
+              isAttrs = v: builtins.isAttrs v;
+            in
+            assert lib.assertMsg (
+              has "name" && isString t.name
+            ) "${fileName}: missing or invalid 'name' (string)";
+            assert lib.assertMsg (
+              has "meta" && isAttrs t.meta
+            ) "${fileName}: missing or invalid 'meta' (attrset)";
+            assert lib.assertMsg (
+              hasMeta "description" && isString t.meta.description
+            ) "${fileName}: missing or invalid 'meta.description' (string)";
+            assert lib.assertMsg (
+              hasMeta "homepage" && isString t.meta.homepage
+            ) "${fileName}: missing or invalid 'meta.homepage' (string)";
+            assert lib.assertMsg (
+              hasMeta "documentation" && isString t.meta.documentation
+            ) "${fileName}: missing or invalid 'meta.documentation' (string)";
+            assert lib.assertMsg (
+              hasMeta "lastChecked" && isString t.meta.lastChecked
+            ) "${fileName}: missing or invalid 'meta.lastChecked' (string)";
+            assert lib.assertMsg (
+              hasMeta "lastChecked" -> builtins.match "[0-9]{4}-[0-9]{2}-[0-9]{2}" t.meta.lastChecked != null
+            ) "${fileName}: 'meta.lastChecked' must be YYYY-MM-DD format";
+            assert lib.assertMsg (
+              hasMeta "hasTelemetry" && isBool t.meta.hasTelemetry
+            ) "${fileName}: missing or invalid 'meta.hasTelemetry' (bool)";
+            assert lib.assertMsg (
+              has "variables" && isAttrs t.variables
+            ) "${fileName}: missing or invalid 'variables' (attrset)";
+            assert lib.assertMsg (
+              has "variables" -> builtins.all isString (builtins.attrValues t.variables)
+            ) "${fileName}: all values in 'variables' must be strings";
+            assert lib.assertMsg (
+              has "commands" && isAttrs t.commands
+            ) "${fileName}: missing or invalid 'commands' (attrset)";
+            assert lib.assertMsg (
+              has "config" && isAttrs t.config
+            ) "${fileName}: missing or invalid 'config' (attrset)";
+            t;
+
+          toolDefs = lib.zipListsWith validateTool toolFiles (map import toolFiles);
+
+          allToolFiles =
+            let
+              entries = builtins.readDir ./tools;
+              nixFiles = lib.filterAttrs (name: type: type == "regular" && lib.hasSuffix ".nix" name) entries;
+            in
+            map (name: ./tools + "/${name}") (builtins.attrNames nixFiles);
+
+          allToolDefs = lib.zipListsWith validateTool allToolFiles (map import allToolFiles);
+
+          validateAll = builtins.deepSeq (map (t: t.name) allToolDefs) true;
 
           tools = builtins.listToAttrs (
             map (t: {
@@ -25,7 +85,7 @@
           variables = builtins.foldl' (acc: t: acc // t.variables) { } toolDefs;
         in
         {
-          inherit variables tools;
+          inherit variables tools validateAll;
 
           homeManagerModules =
             builtins.listToAttrs (

--- a/hk.pkl
+++ b/hk.pkl
@@ -40,8 +40,13 @@ hooks {
     stash = "git"
     steps {
       ...linters
+      ["validate-tools"] {
+        glob = List("tools/*.nix")
+        check = "nix eval .#validateAll > /dev/null"
+      }
       ["readme-vars"] {
         glob = List("tools/*.nix")
+        depends = List("validate-tools")
         fix = "mise run readme-vars && git add README.md"
       }
     }

--- a/tools/_alejandra.nix
+++ b/tools/_alejandra.nix
@@ -9,4 +9,5 @@
   };
   variables = { };
   commands = { };
+  config = { };
 }

--- a/tools/_deadnix.nix
+++ b/tools/_deadnix.nix
@@ -9,4 +9,5 @@
   };
   variables = { };
   commands = { };
+  config = { };
 }

--- a/tools/_flake-parts.nix
+++ b/tools/_flake-parts.nix
@@ -9,4 +9,5 @@
   };
   variables = { };
   commands = { };
+  config = { };
 }

--- a/tools/_flutter.nix
+++ b/tools/_flutter.nix
@@ -12,4 +12,5 @@
     disable = "flutter --disable-analytics";
     status = "flutter config";
   };
+  config = { };
 }

--- a/tools/_go.nix
+++ b/tools/_go.nix
@@ -12,4 +12,5 @@
     disable = "go telemetry off";
     status = "go telemetry";
   };
+  config = { };
 }

--- a/tools/_golangci-lint.nix
+++ b/tools/_golangci-lint.nix
@@ -9,4 +9,5 @@
   };
   variables = { };
   commands = { };
+  config = { };
 }

--- a/tools/_goreleaser.nix
+++ b/tools/_goreleaser.nix
@@ -9,4 +9,5 @@
   };
   variables = { };
   commands = { };
+  config = { };
 }

--- a/tools/_gosec.nix
+++ b/tools/_gosec.nix
@@ -9,4 +9,5 @@
   };
   variables = { };
   commands = { };
+  config = { };
 }

--- a/tools/_gotestsum.nix
+++ b/tools/_gotestsum.nix
@@ -9,4 +9,5 @@
   };
   variables = { };
   commands = { };
+  config = { };
 }

--- a/tools/_govulncheck.nix
+++ b/tools/_govulncheck.nix
@@ -11,4 +11,5 @@
   commands = {
     disable = "go telemetry off";
   };
+  config = { };
 }

--- a/tools/_hk.nix
+++ b/tools/_hk.nix
@@ -9,4 +9,5 @@
   };
   variables = { };
   commands = { };
+  config = { };
 }

--- a/tools/_home-manager.nix
+++ b/tools/_home-manager.nix
@@ -9,4 +9,5 @@
   };
   variables = { };
   commands = { };
+  config = { };
 }

--- a/tools/_hugo.nix
+++ b/tools/_hugo.nix
@@ -9,4 +9,5 @@
   };
   variables = { };
   commands = { };
+  config = { };
 }

--- a/tools/_import-tree.nix
+++ b/tools/_import-tree.nix
@@ -9,4 +9,5 @@
   };
   variables = { };
   commands = { };
+  config = { };
 }

--- a/tools/_markdownlint-cli2.nix
+++ b/tools/_markdownlint-cli2.nix
@@ -9,4 +9,5 @@
   };
   variables = { };
   commands = { };
+  config = { };
 }

--- a/tools/_mise.nix
+++ b/tools/_mise.nix
@@ -12,4 +12,5 @@
   };
   variables = { };
   commands = { };
+  config = { };
 }

--- a/tools/_nil.nix
+++ b/tools/_nil.nix
@@ -9,4 +9,5 @@
   };
   variables = { };
   commands = { };
+  config = { };
 }

--- a/tools/_nix-darwin.nix
+++ b/tools/_nix-darwin.nix
@@ -9,4 +9,5 @@
   };
   variables = { };
   commands = { };
+  config = { };
 }

--- a/tools/_nixd.nix
+++ b/tools/_nixd.nix
@@ -9,4 +9,5 @@
   };
   variables = { };
   commands = { };
+  config = { };
 }

--- a/tools/_nixfmt-rfc-style.nix
+++ b/tools/_nixfmt-rfc-style.nix
@@ -9,4 +9,5 @@
   };
   variables = { };
   commands = { };
+  config = { };
 }

--- a/tools/_nixos-generators.nix
+++ b/tools/_nixos-generators.nix
@@ -9,4 +9,5 @@
   };
   variables = { };
   commands = { };
+  config = { };
 }

--- a/tools/_nixpkgs-fmt.nix
+++ b/tools/_nixpkgs-fmt.nix
@@ -9,4 +9,5 @@
   };
   variables = { };
   commands = { };
+  config = { };
 }

--- a/tools/_nixpkgs.nix
+++ b/tools/_nixpkgs.nix
@@ -9,4 +9,5 @@
   };
   variables = { };
   commands = { };
+  config = { };
 }

--- a/tools/_nodejs.nix
+++ b/tools/_nodejs.nix
@@ -13,4 +13,5 @@
   };
   variables = { };
   commands = { };
+  config = { };
 }

--- a/tools/_pkl.nix
+++ b/tools/_pkl.nix
@@ -9,4 +9,5 @@
   };
   variables = { };
   commands = { };
+  config = { };
 }

--- a/tools/_pnpm.nix
+++ b/tools/_pnpm.nix
@@ -9,4 +9,5 @@
   };
   variables = { };
   commands = { };
+  config = { };
 }

--- a/tools/_react-native-windows.nix
+++ b/tools/_react-native-windows.nix
@@ -11,4 +11,5 @@
   commands = {
     disable = "npx react-native run-windows --no-telemetry";
   };
+  config = { };
 }

--- a/tools/_shellcheck.nix
+++ b/tools/_shellcheck.nix
@@ -9,4 +9,5 @@
   };
   variables = { };
   commands = { };
+  config = { };
 }

--- a/tools/_shfmt.nix
+++ b/tools/_shfmt.nix
@@ -9,4 +9,5 @@
   };
   variables = { };
   commands = { };
+  config = { };
 }

--- a/tools/_statix.nix
+++ b/tools/_statix.nix
@@ -9,4 +9,5 @@
   };
   variables = { };
   commands = { };
+  config = { };
 }

--- a/tools/_taplo.nix
+++ b/tools/_taplo.nix
@@ -9,4 +9,5 @@
   };
   variables = { };
   commands = { };
+  config = { };
 }

--- a/tools/_templ.nix
+++ b/tools/_templ.nix
@@ -9,4 +9,5 @@
   };
   variables = { };
   commands = { };
+  config = { };
 }

--- a/tools/_vue.nix
+++ b/tools/_vue.nix
@@ -9,4 +9,5 @@
   };
   variables = { };
   commands = { };
+  config = { };
 }

--- a/tools/_yamllint.nix
+++ b/tools/_yamllint.nix
@@ -9,4 +9,5 @@
   };
   variables = { };
   commands = { };
+  config = { };
 }

--- a/tools/amplify-cli.nix
+++ b/tools/amplify-cli.nix
@@ -11,4 +11,5 @@
     AMPLIFY_DISABLE_TELEMETRY = "1";
   };
   commands = { };
+  config = { };
 }

--- a/tools/angular-cli.nix
+++ b/tools/angular-cli.nix
@@ -14,4 +14,5 @@
     disable = "ng analytics disable";
     status = "ng analytics info";
   };
+  config = { };
 }

--- a/tools/astro.nix
+++ b/tools/astro.nix
@@ -11,4 +11,5 @@
     ASTRO_TELEMETRY_DISABLED = "1";
   };
   commands = { };
+  config = { };
 }

--- a/tools/avalonia.nix
+++ b/tools/avalonia.nix
@@ -11,4 +11,5 @@
     AVALONIA_TELEMETRY_OPTOUT = "1";
   };
   commands = { };
+  config = { };
 }

--- a/tools/aws-cdk.nix
+++ b/tools/aws-cdk.nix
@@ -14,4 +14,5 @@
     disable = "cdk cli-telemetry --disable";
     status = "cdk cli-telemetry --status";
   };
+  config = { };
 }

--- a/tools/bun.nix
+++ b/tools/bun.nix
@@ -11,4 +11,5 @@
     DO_NOT_TRACK = "1";
   };
   commands = { };
+  config = { };
 }

--- a/tools/claude-code.nix
+++ b/tools/claude-code.nix
@@ -15,4 +15,5 @@
     CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC = "1";
   };
   commands = { };
+  config = { };
 }

--- a/tools/coder.nix
+++ b/tools/coder.nix
@@ -11,4 +11,5 @@
     CODER_TELEMETRY_ENABLE = "false";
   };
   commands = { };
+  config = { };
 }

--- a/tools/devbox.nix
+++ b/tools/devbox.nix
@@ -11,4 +11,5 @@
     DO_NOT_TRACK = "1";
   };
   commands = { };
+  config = { };
 }

--- a/tools/devpod.nix
+++ b/tools/devpod.nix
@@ -11,4 +11,5 @@
     DEVPOD_DISABLE_TELEMETRY = "true";
   };
   commands = { };
+  config = { };
 }

--- a/tools/do-not-track.nix
+++ b/tools/do-not-track.nix
@@ -2,6 +2,8 @@
   name = "do-not-track";
   meta = {
     description = "Defaults that are not a standard but are used by CLI tools";
+    homepage = "https://github.com/adampie/opt-out";
+    documentation = "https://github.com/adampie/opt-out";
     lastChecked = "2026-02-22";
     hasTelemetry = true;
   };
@@ -10,4 +12,5 @@
     NO_TELEMETRY = "1";
   };
   commands = { };
+  config = { };
 }

--- a/tools/dotnet.nix
+++ b/tools/dotnet.nix
@@ -11,4 +11,5 @@
     DOTNET_CLI_TELEMETRY_OPTOUT = "1";
   };
   commands = { };
+  config = { };
 }

--- a/tools/dvc.nix
+++ b/tools/dvc.nix
@@ -14,4 +14,5 @@
     disable = "dvc config core.analytics false";
     status = "dvc config core.analytics";
   };
+  config = { };
 }

--- a/tools/earthly.nix
+++ b/tools/earthly.nix
@@ -11,4 +11,5 @@
     EARTHLY_DISABLE_ANALYTICS = "1";
   };
   commands = { };
+  config = { };
 }

--- a/tools/expo.nix
+++ b/tools/expo.nix
@@ -11,4 +11,5 @@
     EXPO_NO_TELEMETRY = "1";
   };
   commands = { };
+  config = { };
 }

--- a/tools/fastlane.nix
+++ b/tools/fastlane.nix
@@ -11,4 +11,5 @@
     FASTLANE_OPT_OUT_USAGE = "YES";
   };
   commands = { };
+  config = { };
 }

--- a/tools/gatsby.nix
+++ b/tools/gatsby.nix
@@ -14,4 +14,5 @@
     disable = "gatsby telemetry --disable";
     status = "gatsby telemetry";
   };
+  config = { };
 }

--- a/tools/gemini.nix
+++ b/tools/gemini.nix
@@ -11,4 +11,5 @@
     GEMINI_TELEMETRY_ENABLED = "false";
   };
   commands = { };
+  config = { };
 }

--- a/tools/gitpod.nix
+++ b/tools/gitpod.nix
@@ -11,4 +11,5 @@
     DO_NOT_TRACK = "1";
   };
   commands = { };
+  config = { };
 }

--- a/tools/grafana.nix
+++ b/tools/grafana.nix
@@ -11,4 +11,5 @@
     GF_ANALYTICS_REPORTING_ENABLED = "false";
   };
   commands = { };
+  config = { };
 }

--- a/tools/hashicorp.nix
+++ b/tools/hashicorp.nix
@@ -11,4 +11,5 @@
     CHECKPOINT_DISABLE = "1";
   };
   commands = { };
+  config = { };
 }

--- a/tools/homebrew.nix
+++ b/tools/homebrew.nix
@@ -13,4 +13,5 @@
   commands = {
     status = "brew analytics";
   };
+  config = { };
 }

--- a/tools/localstack.nix
+++ b/tools/localstack.nix
@@ -11,4 +11,5 @@
     DISABLE_EVENTS = "1";
   };
   commands = { };
+  config = { };
 }

--- a/tools/meilisearch.nix
+++ b/tools/meilisearch.nix
@@ -11,4 +11,5 @@
     MEILI_NO_ANALYTICS = "";
   };
   commands = { };
+  config = { };
 }

--- a/tools/meteor.nix
+++ b/tools/meteor.nix
@@ -11,4 +11,5 @@
     DO_NOT_TRACK = "1";
   };
   commands = { };
+  config = { };
 }

--- a/tools/microsoft-go.nix
+++ b/tools/microsoft-go.nix
@@ -11,4 +11,5 @@
     MS_GOTOOLCHAIN_TELEMETRY_ENABLED = "0";
   };
   commands = { };
+  config = { };
 }

--- a/tools/n8n.nix
+++ b/tools/n8n.nix
@@ -11,4 +11,5 @@
     N8N_DIAGNOSTICS_ENABLED = "false";
   };
   commands = { };
+  config = { };
 }

--- a/tools/nextjs.nix
+++ b/tools/nextjs.nix
@@ -13,4 +13,5 @@
   commands = {
     status = "next telemetry status";
   };
+  config = { };
 }

--- a/tools/nuxtjs.nix
+++ b/tools/nuxtjs.nix
@@ -13,4 +13,5 @@
   commands = {
     status = "npx nuxt telemetry status";
   };
+  config = { };
 }

--- a/tools/platformio.nix
+++ b/tools/platformio.nix
@@ -13,4 +13,5 @@
   commands = {
     status = "pio settings get";
   };
+  config = { };
 }

--- a/tools/prisma.nix
+++ b/tools/prisma.nix
@@ -11,4 +11,5 @@
     CHECKPOINT_DISABLE = "1";
   };
   commands = { };
+  config = { };
 }

--- a/tools/redwood.nix
+++ b/tools/redwood.nix
@@ -11,4 +11,5 @@
     REDWOOD_DISABLE_TELEMETRY = "1";
   };
   commands = { };
+  config = { };
 }

--- a/tools/signoz.nix
+++ b/tools/signoz.nix
@@ -11,4 +11,5 @@
     TELEMETRY_ENABLED = "false";
   };
   commands = { };
+  config = { };
 }

--- a/tools/storybook.nix
+++ b/tools/storybook.nix
@@ -11,4 +11,5 @@
     STORYBOOK_DISABLE_TELEMETRY = "true";
   };
   commands = { };
+  config = { };
 }

--- a/tools/turbo.nix
+++ b/tools/turbo.nix
@@ -13,4 +13,5 @@
   commands = {
     status = "turbo telemetry status";
   };
+  config = { };
 }

--- a/tools/vercel.nix
+++ b/tools/vercel.nix
@@ -13,4 +13,5 @@
   commands = {
     status = "vercel telemetry status";
   };
+  config = { };
 }

--- a/tools/wrangler.nix
+++ b/tools/wrangler.nix
@@ -13,4 +13,5 @@
   commands = {
     status = "npx wrangler telemetry status";
   };
+  config = { };
 }

--- a/tools/xmake.nix
+++ b/tools/xmake.nix
@@ -13,4 +13,5 @@
   commands = {
     status = "xmake show -l envs";
   };
+  config = { };
 }

--- a/tools/yarn.nix
+++ b/tools/yarn.nix
@@ -11,4 +11,5 @@
     YARN_ENABLE_TELEMETRY = "0";
   };
   commands = { };
+  config = { };
 }


### PR DESCRIPTION
## Summary

- Investigate and exclude 50+ tools from Homebrew dependency tree — none have environment variable telemetry opt-out
- Add Nix-native schema validation for all tool definitions (including `_` prefixed excluded tools)
- Add `validateAll` flake output, pre-commit hook, and CI job to enforce the schema

## Schema validation

Every tool file is now validated against required fields:
- `name` (string)
- `meta.description` (string)
- `meta.homepage` (string)
- `meta.documentation` (string)
- `meta.lastChecked` (string, YYYY-MM-DD)
- `meta.hasTelemetry` (bool)
- `variables` (attrset of strings)
- `commands` (attrset)
- `config` (attrset)

Validation runs via `nix eval .#validateAll` in pre-commit (`hk.pkl`) and CI (`lint.yml`).

## Test plan

- [x] `nix flake check` passes
- [x] `nix eval .#validateAll` returns `true`
- [ ] CI `validate-tools` job passes