### PR TITLE
Exclude mkdocs: no telemetry found

### DIFF
--- a/tools/_mkdocs.nix
+++ b/tools/_mkdocs.nix
@@ -1,0 +1,13 @@
+{
+  name = "mkdocs";
+  meta = {
+    description = "Static site generator that builds documentation websites from Markdown files";
+    homepage = "https://github.com/mkdocs/mkdocs";
+    documentation = "https://www.mkdocs.org/user-guide/configuration/";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary

- Investigated mkdocs for telemetry, analytics, or crash reporting with environment variable opt-out
- No telemetry features found in the mkdocs codebase
- Created `tools/_mkdocs.nix` as an excluded tool file with `hasTelemetry = false`

Closes #140