### PR TITLE
Exclude spf13 (Cobra, Viper, pflag): no telemetry

### DIFF
--- a/tools/_cobra.nix
+++ b/tools/_cobra.nix
@@ -1,0 +1,13 @@
+{
+  name = "cobra";
+  meta = {
+    description = "A library for building powerful modern CLI applications in Go";
+    homepage = "https://github.com/spf13/cobra";
+    documentation = "https://github.com/spf13/cobra";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_pflag.nix
+++ b/tools/_pflag.nix
@@ -1,0 +1,13 @@
+{
+  name = "pflag";
+  meta = {
+    description = "A drop-in replacement for Go's flag package implementing POSIX/GNU-style flags";
+    homepage = "https://github.com/spf13/pflag";
+    documentation = "https://github.com/spf13/pflag";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_viper.nix
+++ b/tools/_viper.nix
@@ -1,0 +1,13 @@
+{
+  name = "viper";
+  meta = {
+    description = "A complete configuration solution for Go applications";
+    homepage = "https://github.com/spf13/viper";
+    documentation = "https://github.com/spf13/viper";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary

- Investigated all three spf13 Go libraries: Cobra, Viper, and pflag
- None of the libraries implement telemetry, analytics, or crash reporting
- No environment variables exist to opt out of — excluded with `hasTelemetry = false`

## Test plan

- [x] `mise run fmt` passes
- [x] `mise run lint` passes
- [x] `mise run flake-check` passes

Closes #91