### PR TITLE
Exclude nats: no telemetry opt-out via environment variables

### DIFF
--- a/tools/_conftest.nix
+++ b/tools/_conftest.nix
@@ -1,0 +1,13 @@
+{
+  name = "conftest";
+  meta = {
+    description = "Tool for writing tests against structured configuration data using Rego";
+    homepage = "https://github.com/open-policy-agent/conftest";
+    documentation = "https://www.conftest.dev/";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_nats.nix
+++ b/tools/_nats.nix
@@ -1,0 +1,13 @@
+{
+  name = "nats";
+  meta = {
+    description = "NATS is a connective technology built for the hyper connected world, providing a simple, secure, and performant messaging system.";
+    homepage = "https://github.com/nats-io/nats-server";
+    documentation = "https://docs.nats.io";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_opa.nix
+++ b/tools/_opa.nix
@@ -1,0 +1,15 @@
+{
+  name = "opa";
+  meta = {
+    description = "General-purpose policy engine for cloud-native environments";
+    homepage = "https://github.com/open-policy-agent/opa";
+    documentation = "https://www.openpolicyagent.org/docs/latest/privacy/";
+    lastChecked = "2026-03-14";
+    hasTelemetry = true;
+  };
+  variables = { };
+  commands = {
+    disable = "opa run --disable-telemetry";
+  };
+  config = { };
+}


### PR DESCRIPTION
## Summary

- Investigated NATS (nats-server, nats.go Go client, and natscli)
- None of these packages implement telemetry or analytics with environment variable opt-out
- Created `tools/_nats.nix` to document the investigation result

## Research

Checked:
- `nats-io/nats-server` — no telemetry features found; `NATS_LOGGING` is test-only
- `nats-io/nats.go` — Go client library, no telemetry
- `nats-io/natscli` — `NATS_*` env vars are all connection config (URL, user, password, token, etc.), not telemetry

Closes #86