### PR TITLE
Exclude opa and conftest: no env var telemetry opt-out

### DIFF
--- a/tools/_conftest.nix
+++ b/tools/_conftest.nix
@@ -1,0 +1,13 @@
+{
+  name = "conftest";
+  meta = {
+    description = "Tool for writing tests against structured configuration data using Rego";
+    homepage = "https://github.com/open-policy-agent/conftest";
+    documentation = "https://www.conftest.dev/";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_opa.nix
+++ b/tools/_opa.nix
@@ -1,0 +1,15 @@
+{
+  name = "opa";
+  meta = {
+    description = "General-purpose policy engine for cloud-native environments";
+    homepage = "https://github.com/open-policy-agent/opa";
+    documentation = "https://www.openpolicyagent.org/docs/latest/privacy/";
+    lastChecked = "2026-03-14";
+    hasTelemetry = true;
+  };
+  variables = { };
+  commands = {
+    disable = "opa run --disable-telemetry";
+  };
+  config = { };
+}


### PR DESCRIPTION
## Summary

- OPA's telemetry was removed in recent versions; the current behavior is only a version check against the GitHub API that sends no instance data. Opt-out is via `--disable-telemetry` CLI flag only — no environment variable available.
- Conftest has no telemetry at all.

Neither tool qualifies for the flake (no env var opt-out). Both are recorded as excluded files.

Closes #99