### PR TITLE
Exclude c-ares, brotli, ca-certificates, ada-url: no telemetry

### DIFF
--- a/tools/_ada-url.nix
+++ b/tools/_ada-url.nix
@@ -1,0 +1,13 @@
+{
+  name = "ada-url";
+  meta = {
+    description = "WHATWG-compliant and fast URL parser written in modern C++";
+    homepage = "https://github.com/ada-url/ada";
+    documentation = "https://github.com/ada-url/ada/blob/main/README.md";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_brotli.nix
+++ b/tools/_brotli.nix
@@ -1,0 +1,13 @@
+{
+  name = "brotli";
+  meta = {
+    description = "Generic-purpose lossless compression algorithm by Google";
+    homepage = "https://github.com/google/brotli";
+    documentation = "https://github.com/google/brotli/blob/master/README.md";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_c-ares.nix
+++ b/tools/_c-ares.nix
@@ -1,0 +1,13 @@
+{
+  name = "c-ares";
+  meta = {
+    description = "C library for asynchronous DNS requests";
+    homepage = "https://github.com/c-ares/c-ares";
+    documentation = "https://c-ares.org/docs.html";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_ca-certificates.nix
+++ b/tools/_ca-certificates.nix
@@ -1,0 +1,13 @@
+{
+  name = "ca-certificates";
+  meta = {
+    description = "Mozilla's CA certificate bundle for SSL/TLS verification";
+    homepage = "https://curl.se/docs/caextract.html";
+    documentation = "https://wiki.mozilla.org/CA";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary

- Exclude c-ares: C library for async DNS, no telemetry
- Exclude brotli: compression library, no telemetry
- Exclude ca-certificates: data-only CA bundle, no telemetry
- Exclude ada-url: C++ URL parser, no telemetry

Closes #187 #186 #185 #184

## Test plan

- [x] `nix eval .#validateAll` passes