### PR TITLE
Exclude colorama, pymdown-extensions, mkdocs-material, validate, gongs: no telemetry

### DIFF
--- a/tools/_colorama.nix
+++ b/tools/_colorama.nix
@@ -1,0 +1,13 @@
+{
+  name = "colorama";
+  meta = {
+    description = "Cross-platform colored terminal text in Python";
+    homepage = "https://github.com/tartley/colorama";
+    documentation = "https://github.com/tartley/colorama/blob/master/README.rst";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_gongs.nix
+++ b/tools/_gongs.nix
@@ -1,0 +1,13 @@
+{
+  name = "gongs";
+  meta = {
+    description = "Thin wrapper around NATS Jetstream client using Go generics";
+    homepage = "https://github.com/sl1pm4t/gongs";
+    documentation = "https://github.com/sl1pm4t/gongs/blob/main/README.md";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_mkdocs-material.nix
+++ b/tools/_mkdocs-material.nix
@@ -1,0 +1,13 @@
+{
+  name = "mkdocs-material";
+  meta = {
+    description = "Material Design theme for MkDocs";
+    homepage = "https://github.com/squidfunk/mkdocs-material";
+    documentation = "https://squidfunk.github.io/mkdocs-material/setup/ensuring-data-privacy/";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_pymdown-extensions.nix
+++ b/tools/_pymdown-extensions.nix
@@ -1,0 +1,13 @@
+{
+  name = "pymdown-extensions";
+  meta = {
+    description = "Extensions for Python-Markdown";
+    homepage = "https://github.com/facelessuser/pymdown-extensions";
+    documentation = "https://facelessuser.github.io/pymdown-extensions/";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_validate.nix
+++ b/tools/_validate.nix
@@ -1,0 +1,13 @@
+{
+  name = "validate";
+  meta = {
+    description = "Go struct and field validation library";
+    homepage = "https://github.com/go-playground/validator";
+    documentation = "https://pkg.go.dev/github.com/go-playground/validator/v10";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary

- Exclude colorama: Python terminal color library, no telemetry
- Exclude pymdown-extensions: Python-Markdown extensions, no telemetry
- Exclude mkdocs-material: MkDocs theme, no build-tool telemetry (analytics features are for generated sites only)
- Exclude validate: Go struct validation library, no telemetry
- Exclude gongs: Go NATS Jetstream wrapper, no telemetry

Closes #143 #142 #141 #124 #123

## Test plan

- [x] `nix eval .#validateAll` passes