### PR TITLE
Exclude pkg/errors, tint, kr/pretty, flatten, go-flags: no telemetry

### DIFF
--- a/tools/_flatten.nix
+++ b/tools/_flatten.nix
@@ -1,0 +1,13 @@
+{
+  name = "flatten";
+  meta = {
+    description = "Flatten nested Go maps and JSON into one-dimensional scalar sets";
+    homepage = "https://github.com/jeremywohl/flatten";
+    documentation = "https://pkg.go.dev/github.com/jeremywohl/flatten";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_go-flags.nix
+++ b/tools/_go-flags.nix
@@ -1,0 +1,13 @@
+{
+  name = "go-flags";
+  meta = {
+    description = "Go command line option parser";
+    homepage = "https://github.com/jessevdk/go-flags";
+    documentation = "https://pkg.go.dev/github.com/jessevdk/go-flags";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_kr-pretty.nix
+++ b/tools/_kr-pretty.nix
@@ -1,0 +1,13 @@
+{
+  name = "kr-pretty";
+  meta = {
+    description = "Pretty printing for Go values";
+    homepage = "https://github.com/kr/pretty";
+    documentation = "https://pkg.go.dev/github.com/kr/pretty";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_pkg-errors.nix
+++ b/tools/_pkg-errors.nix
@@ -1,0 +1,13 @@
+{
+  name = "pkg-errors";
+  meta = {
+    description = "Simple error handling primitives for Go";
+    homepage = "https://github.com/pkg/errors";
+    documentation = "https://pkg.go.dev/github.com/pkg/errors";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_tint.nix
+++ b/tools/_tint.nix
@@ -1,0 +1,13 @@
+{
+  name = "tint";
+  meta = {
+    description = "slog.Handler that writes colorized log output";
+    homepage = "https://github.com/lmittmann/tint";
+    documentation = "https://pkg.go.dev/github.com/lmittmann/tint";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary

- Exclude pkg/errors: Go error wrapping library, no telemetry
- Exclude tint: Go slog handler for colorized output, no telemetry
- Exclude kr/pretty: Go pretty-printing library, no telemetry
- Exclude flatten: Go map/JSON flattening utility, no telemetry
- Exclude go-flags: Go command-line option parser, no telemetry

Closes #122 #121 #120 #119 #118

## Test plan

- [x] `nix eval .#validateAll` passes