### PR TITLE
Exclude heptiolabs healthcheck, creasty defaults, chainguard git-urls, tablewriter, Masterminds semver: no telemetry

### DIFF
--- a/tools/_chainguard-git-urls.nix
+++ b/tools/_chainguard-git-urls.nix
@@ -1,0 +1,13 @@
+{
+  name = "chainguard-git-urls";
+  meta = {
+    description = "Go library for parsing git URLs";
+    homepage = "https://github.com/chainguard-dev/git-urls";
+    documentation = "https://pkg.go.dev/github.com/chainguard-dev/git-urls";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_creasty-defaults.nix
+++ b/tools/_creasty-defaults.nix
@@ -1,0 +1,13 @@
+{
+  name = "creasty-defaults";
+  meta = {
+    description = "Go library for initializing structs with default values";
+    homepage = "https://github.com/creasty/defaults";
+    documentation = "https://pkg.go.dev/github.com/creasty/defaults";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_heptiolabs-healthcheck.nix
+++ b/tools/_heptiolabs-healthcheck.nix
@@ -1,0 +1,13 @@
+{
+  name = "heptiolabs-healthcheck";
+  meta = {
+    description = "Go health check library for Kubernetes liveness and readiness probes";
+    homepage = "https://github.com/heptiolabs/healthcheck";
+    documentation = "https://pkg.go.dev/github.com/heptiolabs/healthcheck";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_masterminds-semver.nix
+++ b/tools/_masterminds-semver.nix
@@ -1,0 +1,13 @@
+{
+  name = "masterminds-semver";
+  meta = {
+    description = "Semantic versioning library for Go";
+    homepage = "https://github.com/Masterminds/semver";
+    documentation = "https://pkg.go.dev/github.com/Masterminds/semver/v3";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_tablewriter.nix
+++ b/tools/_tablewriter.nix
@@ -1,0 +1,13 @@
+{
+  name = "tablewriter";
+  meta = {
+    description = "ASCII and Unicode table writer for Go";
+    homepage = "https://github.com/olekukonko/tablewriter";
+    documentation = "https://pkg.go.dev/github.com/olekukonko/tablewriter";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary

- Exclude heptiolabs healthcheck: Go health check library for K8s probes, no telemetry
- Exclude creasty defaults: Go struct default values library, no telemetry
- Exclude chainguard git-urls: Go git URL parser, no telemetry
- Exclude tablewriter: Go ASCII table renderer, no telemetry
- Exclude Masterminds semver: Go semantic versioning library, no telemetry

Closes #117 #116 #115 #114 #113

## Test plan

- [x] `nix eval .#validateAll` passes