### PR TITLE
Exclude 10 Go packages: no telemetry

### DIFF
--- a/tools/_backoff.nix
+++ b/tools/_backoff.nix
@@ -1,0 +1,13 @@
+{
+  name = "backoff";
+  meta = {
+    description = "Go exponential backoff algorithm library";
+    homepage = "https://github.com/cenkalti/backoff";
+    documentation = "https://pkg.go.dev/github.com/cenkalti/backoff/v4";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_doublestar.nix
+++ b/tools/_doublestar.nix
@@ -1,0 +1,13 @@
+{
+  name = "doublestar";
+  meta = {
+    description = "Go path matching with double-star glob patterns";
+    homepage = "https://github.com/bmatcuk/doublestar";
+    documentation = "https://pkg.go.dev/github.com/bmatcuk/doublestar/v4";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_go-keyring.nix
+++ b/tools/_go-keyring.nix
@@ -1,0 +1,13 @@
+{
+  name = "go-keyring";
+  meta = {
+    description = "Go library for system keyring access";
+    homepage = "https://github.com/zalando/go-keyring";
+    documentation = "https://pkg.go.dev/github.com/zalando/go-keyring";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_godotenv.nix
+++ b/tools/_godotenv.nix
@@ -1,0 +1,13 @@
+{
+  name = "godotenv";
+  meta = {
+    description = "Go library for loading .env files";
+    homepage = "https://github.com/joho/godotenv";
+    documentation = "https://pkg.go.dev/github.com/joho/godotenv";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_golang-jwt.nix
+++ b/tools/_golang-jwt.nix
@@ -1,0 +1,13 @@
+{
+  name = "golang-jwt";
+  meta = {
+    description = "Go implementation of JSON Web Tokens";
+    homepage = "https://github.com/golang-jwt/jwt";
+    documentation = "https://pkg.go.dev/github.com/golang-jwt/jwt/v5";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_kubeconform.nix
+++ b/tools/_kubeconform.nix
@@ -1,0 +1,13 @@
+{
+  name = "kubeconform";
+  meta = {
+    description = "Kubernetes manifest validator";
+    homepage = "https://github.com/yannh/kubeconform";
+    documentation = "https://github.com/yannh/kubeconform/blob/master/Readme.md";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_kubepug.nix
+++ b/tools/_kubepug.nix
@@ -1,0 +1,13 @@
+{
+  name = "kubepug";
+  meta = {
+    description = "Kubernetes pre-upgrade API deprecation checker";
+    homepage = "https://github.com/kubepug/kubepug";
+    documentation = "https://kubepug.xyz/";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_mapstructure.nix
+++ b/tools/_mapstructure.nix
@@ -1,0 +1,13 @@
+{
+  name = "mapstructure";
+  meta = {
+    description = "Go library for decoding generic map values into structs";
+    homepage = "https://github.com/mitchellh/mapstructure";
+    documentation = "https://pkg.go.dev/github.com/mitchellh/mapstructure";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_mergo.nix
+++ b/tools/_mergo.nix
@@ -1,0 +1,13 @@
+{
+  name = "mergo";
+  meta = {
+    description = "Go helper for merging structs and maps";
+    homepage = "https://github.com/imdario/mergo";
+    documentation = "https://pkg.go.dev/github.com/imdario/mergo";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_uber-mock.nix
+++ b/tools/_uber-mock.nix
@@ -1,0 +1,13 @@
+{
+  name = "uber-mock";
+  meta = {
+    description = "Go mocking framework (fork of golang/mock)";
+    homepage = "https://github.com/uber-go/mock";
+    documentation = "https://pkg.go.dev/go.uber.org/mock";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary

- Exclude uber mock: Go mocking framework, no telemetry
- Exclude mergo: Go struct/map merging library, no telemetry
- Exclude doublestar: Go double-star glob pattern matching, no telemetry
- Exclude backoff: Go exponential backoff library, no telemetry
- Exclude golang-jwt: Go JWT implementation, no telemetry
- Exclude mapstructure: Go map-to-struct decoder, no telemetry
- Exclude go-keyring: Go system keyring library, no telemetry
- Exclude godotenv: Go .env file loader, no telemetry
- Exclude kubepug: Kubernetes API deprecation checker, no telemetry
- Exclude kubeconform: Kubernetes manifest validator, no telemetry

Closes #112 #111 #110 #109 #108 #107 #106 #105 #104 #103

## Test plan

- [x] `nix eval .#validateAll` passes