### PR TITLE
Exclude 10 Go packages: no telemetry

### DIFF
--- a/tools/_github-go.nix
+++ b/tools/_github-go.nix
@@ -1,0 +1,13 @@
+{
+  name = "github-go";
+  meta = {
+    description = "Go client libraries for the GitHub API";
+    homepage = "https://github.com/google/go-github";
+    documentation = "https://pkg.go.dev/github.com/google/go-github";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_gitlab-go.nix
+++ b/tools/_gitlab-go.nix
@@ -1,0 +1,13 @@
+{
+  name = "gitlab-go";
+  meta = {
+    description = "Go client for the GitLab API";
+    homepage = "https://github.com/xanzy/go-gitlab";
+    documentation = "https://pkg.go.dev/github.com/xanzy/go-gitlab";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_go-openai.nix
+++ b/tools/_go-openai.nix
@@ -1,0 +1,13 @@
+{
+  name = "go-openai";
+  meta = {
+    description = "Go client for the OpenAI API";
+    homepage = "https://github.com/sashabaranov/go-openai";
+    documentation = "https://pkg.go.dev/github.com/sashabaranov/go-openai";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_go-redis.nix
+++ b/tools/_go-redis.nix
@@ -1,0 +1,13 @@
+{
+  name = "go-redis";
+  meta = {
+    description = "Go client for Redis";
+    homepage = "https://github.com/redis/go-redis";
+    documentation = "https://pkg.go.dev/github.com/redis/go-redis/v9";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_grpc-go.nix
+++ b/tools/_grpc-go.nix
@@ -1,0 +1,13 @@
+{
+  name = "grpc-go";
+  meta = {
+    description = "Go implementation of gRPC";
+    homepage = "https://github.com/grpc/grpc-go";
+    documentation = "https://pkg.go.dev/google.golang.org/grpc";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_logrus.nix
+++ b/tools/_logrus.nix
@@ -1,0 +1,13 @@
+{
+  name = "logrus";
+  meta = {
+    description = "Structured, pluggable logging for Go";
+    homepage = "https://github.com/sirupsen/logrus";
+    documentation = "https://pkg.go.dev/github.com/sirupsen/logrus";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_prometheus-go.nix
+++ b/tools/_prometheus-go.nix
@@ -1,0 +1,13 @@
+{
+  name = "prometheus-go";
+  meta = {
+    description = "Prometheus instrumentation library for Go";
+    homepage = "https://github.com/prometheus/client_golang";
+    documentation = "https://pkg.go.dev/github.com/prometheus/client_golang/prometheus";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_testify.nix
+++ b/tools/_testify.nix
@@ -1,0 +1,13 @@
+{
+  name = "testify";
+  meta = {
+    description = "Go testing toolkit with assertions, mocks, and suites";
+    homepage = "https://github.com/stretchr/testify";
+    documentation = "https://pkg.go.dev/github.com/stretchr/testify";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_yaml-go.nix
+++ b/tools/_yaml-go.nix
@@ -1,0 +1,13 @@
+{
+  name = "yaml-go";
+  meta = {
+    description = "YAML parsing libraries for Go";
+    homepage = "https://github.com/go-yaml/yaml";
+    documentation = "https://pkg.go.dev/gopkg.in/yaml.v3";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_zerolog.nix
+++ b/tools/_zerolog.nix
@@ -1,0 +1,13 @@
+{
+  name = "zerolog";
+  meta = {
+    description = "Zero-allocation structured logging for Go";
+    homepage = "https://github.com/rs/zerolog";
+    documentation = "https://pkg.go.dev/github.com/rs/zerolog";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary

- Exclude GitHub Go libraries (go-github, go-gh): API clients, no telemetry
- Exclude go-openai: OpenAI API client, no telemetry
- Exclude YAML Go libraries (go-yaml, goccy/go-yaml): parsing libraries, no telemetry
- Exclude Testify: Go testing toolkit, no telemetry
- Exclude Logrus: Go structured logging, no telemetry
- Exclude Zerolog: Go zero-allocation logging, no telemetry
- Exclude go-redis: Redis client, no self-telemetry
- Exclude gRPC Go: gRPC implementation, no self-telemetry (OpenTelemetry opt-in only)
- Exclude Prometheus Go: metrics instrumentation library, no self-telemetry
- Exclude GitLab Go: GitLab API client, no telemetry

Closes #102 #101 #100 #98 #97 #96 #95 #94 #93 #92

## Test plan

- [x] `nix eval .#validateAll` passes