### PR TITLE
Exclude 10 Go packages: no telemetry

### DIFF
--- a/tools/_aws-sdk-go.nix
+++ b/tools/_aws-sdk-go.nix
@@ -1,0 +1,13 @@
+{
+  name = "aws-sdk-go";
+  meta = {
+    description = "AWS SDK for Go";
+    homepage = "https://github.com/aws/aws-sdk-go-v2";
+    documentation = "https://aws.github.io/aws-sdk-go-v2/docs/";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_charmbracelet.nix
+++ b/tools/_charmbracelet.nix
@@ -1,0 +1,13 @@
+{
+  name = "charmbracelet";
+  meta = {
+    description = "Go TUI libraries (bubbletea, lipgloss, bubbles, glamour)";
+    homepage = "https://github.com/charmbracelet";
+    documentation = "https://charm.sh/";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_echo.nix
+++ b/tools/_echo.nix
@@ -1,0 +1,13 @@
+{
+  name = "echo";
+  meta = {
+    description = "High performance, minimalist Go web framework";
+    homepage = "https://github.com/labstack/echo";
+    documentation = "https://echo.labstack.com/";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_github-cli.nix
+++ b/tools/_github-cli.nix
@@ -1,0 +1,13 @@
+{
+  name = "github-cli";
+  meta = {
+    description = "GitHub's official CLI tool";
+    homepage = "https://github.com/cli/cli";
+    documentation = "https://cli.github.com/manual/";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_go-git.nix
+++ b/tools/_go-git.nix
@@ -1,0 +1,13 @@
+{
+  name = "go-git";
+  meta = {
+    description = "Pure Go git implementation";
+    homepage = "https://github.com/go-git/go-git";
+    documentation = "https://pkg.go.dev/github.com/go-git/go-git/v5";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_go-stdlib-extensions.nix
+++ b/tools/_go-stdlib-extensions.nix
@@ -1,0 +1,13 @@
+{
+  name = "go-stdlib-extensions";
+  meta = {
+    description = "Official Go supplementary packages (golang.org/x/*)";
+    homepage = "https://github.com/golang/go";
+    documentation = "https://pkg.go.dev/golang.org/x";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_google-go.nix
+++ b/tools/_google-go.nix
@@ -1,0 +1,13 @@
+{
+  name = "google-go";
+  meta = {
+    description = "Google Go libraries (protobuf, genproto, api)";
+    homepage = "https://github.com/googleapis/google-cloud-go";
+    documentation = "https://pkg.go.dev/google.golang.org/api";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_hashicorp-go.nix
+++ b/tools/_hashicorp-go.nix
@@ -1,0 +1,13 @@
+{
+  name = "hashicorp-go";
+  meta = {
+    description = "HashiCorp Go utility libraries (go-multierror, go-version, hcl, etc.)";
+    homepage = "https://github.com/hashicorp";
+    documentation = "https://pkg.go.dev/github.com/hashicorp";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_kubernetes-go-client.nix
+++ b/tools/_kubernetes-go-client.nix
@@ -1,0 +1,13 @@
+{
+  name = "kubernetes-go-client";
+  meta = {
+    description = "Kubernetes Go client libraries (k8s.io/client-go, api, apimachinery)";
+    homepage = "https://github.com/kubernetes/client-go";
+    documentation = "https://pkg.go.dev/k8s.io/client-go";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}

--- a/tools/_kubernetes-sigs.nix
+++ b/tools/_kubernetes-sigs.nix
@@ -1,0 +1,13 @@
+{
+  name = "kubernetes-sigs";
+  meta = {
+    description = "Kubernetes SIG libraries (sigs.k8s.io packages)";
+    homepage = "https://github.com/kubernetes-sigs";
+    documentation = "https://pkg.go.dev/sigs.k8s.io";
+    lastChecked = "2026-03-14";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary

- Exclude Go stdlib extensions (golang.org/x/*): official supplementary packages, no telemetry
- Exclude Kubernetes SIGs (sigs.k8s.io/*): infrastructure libraries, no telemetry
- Exclude Kubernetes Go client (k8s.io/client-go): API client, no telemetry
- Exclude Echo: Go web framework, no telemetry
- Exclude HashiCorp Go libraries: utility libraries (not CLI tools), no telemetry
- Exclude Google Go libraries (protobuf, genproto, api): no self-telemetry
- Exclude go-git: pure Go git implementation, no telemetry
- Exclude GitHub CLI: no env var telemetry opt-out
- Exclude Charmbracelet: TUI libraries, no telemetry
- Exclude AWS SDK Go: no self-telemetry env var opt-out

Closes #90 #89 #88 #85 #84 #83 #82 #81 #80 #79

## Test plan

- [x] `nix eval .#validateAll` passes