### PR TITLE
Exclude 4 Go packages: no telemetry

### DIFF
--- a/tools/_google-go.nix
+++ b/tools/_google-go.nix
@@ -1,10 +1,10 @@
 {
   name = "google-go";
   meta = {
-    description = "Google Go libraries (protobuf, genproto, api)";
+    description = "Google Go libraries (go-cmp, go-github, uuid, protobuf, genproto, api)";
     homepage = "https://github.com/googleapis/google-cloud-go";
     documentation = "https://pkg.go.dev/google.golang.org/api";
-    lastChecked = "2026-03-14";
+    lastChecked = "2026-03-26";
     hasTelemetry = false;
   };
   variables = { };


### PR DESCRIPTION
## Summary
- Updated `tools/_google-go.nix` to include `go-cmp`, `go-github`, and `uuid` in the description
- All four packages are pure utility libraries with no telemetry, analytics, or crash reporting
- No environment variable opt-out exists for any of these packages

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)