### PR TITLE
Exclude 2 Go packages: no telemetry (#84)

### DIFF
--- a/tools/_hashicorp-go.nix
+++ b/tools/_hashicorp-go.nix
@@ -1,10 +1,10 @@
 {
   name = "hashicorp-go";
   meta = {
-    description = "HashiCorp Go utility libraries (go-multierror, go-version, hcl, etc.)";
+    description = "HashiCorp Go utility libraries (go-multierror, go-version, go-tfe, terraform-json, hcl, etc.)";
     homepage = "https://github.com/hashicorp";
     documentation = "https://pkg.go.dev/github.com/hashicorp";
-    lastChecked = "2026-03-14";
+    lastChecked = "2026-03-26";
     hasTelemetry = false;
   };
   variables = { };


### PR DESCRIPTION
## Summary
- Investigated `github.com/hashicorp/go-tfe` and `github.com/hashicorp/terraform-json` from issue #84
- Both packages have **no telemetry** — no checkpoint, analytics, or tracking code found
- Updated existing `tools/_hashicorp-go.nix` to include these packages in the description and refreshed `lastChecked` date

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)