### PR TITLE
Exclude Argo CD: no telemetry

### DIFF
--- a/tools/_argocd.nix
+++ b/tools/_argocd.nix
@@ -3,7 +3,7 @@
   meta = {
     description = "Declarative continuous delivery tool for Kubernetes";
     homepage = "https://github.com/argoproj/argo-cd";
-    documentation = "https://argo-cd.readthedocs.io/en/stable/operator-manual/notifications/monitoring/";
+    documentation = "https://argo-cd.readthedocs.io/en/stable/";
     lastChecked = "2026-03-27";
     hasTelemetry = false;
   };


### PR DESCRIPTION
## Summary

- Investigated Argo CD for telemetry opt-out environment variables
- Argo CD has **no default telemetry**. Its analytics features (Google Analytics in UI, OpenTelemetry tracing) are all opt-in and admin-configured — they don't report back to the Argo CD project
- Added as excluded tool (`tools/_argocd.nix`) with `hasTelemetry = false`

Closes #78

https://claude.ai/code/session_016BRpedq5WrTBXdGsDFNe7K