### PR TITLE
Exclude Anthropic SDK Go: no telemetry

### DIFF
--- a/tools/_anthropic-sdk-go.nix
+++ b/tools/_anthropic-sdk-go.nix
@@ -1,0 +1,13 @@
+{
+  name = "anthropic-sdk-go";
+  meta = {
+    description = "Go client library for the Anthropic API";
+    homepage = "https://github.com/anthropics/anthropic-sdk-go";
+    documentation = "https://github.com/anthropics/anthropic-sdk-go";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated Anthropic SDK Go for telemetry opt-out
- No telemetry mechanism found — the SDK does not collect analytics or telemetry data
- Added as excluded tool (`_anthropic-sdk-go.nix`) with `hasTelemetry = false`

Closes #77