### PR TITLE
Exclude vitest: no telemetry

### DIFF
--- a/tools/_vitest.nix
+++ b/tools/_vitest.nix
@@ -1,0 +1,13 @@
+{
+  name = "vitest";
+  meta = {
+    description = "Next generation testing framework";
+    homepage = "https://github.com/vitest-dev/vitest";
+    documentation = "https://github.com/vitest-dev/vitest";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated vitest for telemetry opt-out
- Vitest does not collect analytics or telemetry — its OpenTelemetry support is an opt-in feature for users to trace their own test runs
- Added as excluded tool (`_vitest.nix`) with `hasTelemetry = false`

Closes #76