### PR TITLE
Exclude vite: no telemetry

### DIFF
--- a/tools/_vite.nix
+++ b/tools/_vite.nix
@@ -1,0 +1,13 @@
+{
+  name = "vite";
+  meta = {
+    description = "Next generation frontend build tool";
+    homepage = "https://github.com/vitejs/vite";
+    documentation = "https://github.com/vitejs/vite";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated vite for telemetry opt-out
- Vite does not collect analytics or telemetry data
- Added as excluded tool (`_vite.nix`) with `hasTelemetry = false`

Closes #75