### PR TITLE
Exclude typescript: no telemetry

### DIFF
--- a/tools/_typescript.nix
+++ b/tools/_typescript.nix
@@ -1,0 +1,13 @@
+{
+  name = "typescript";
+  meta = {
+    description = "Typed superset of JavaScript that compiles to plain JavaScript";
+    homepage = "https://github.com/microsoft/TypeScript";
+    documentation = "https://github.com/microsoft/TypeScript";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated TypeScript for telemetry opt-out
- TypeScript's tsserver telemetry is editor-provided (consumed by VS Code), not independently collected
- The compiler (`tsc`) does not collect telemetry; `--enableTelemetry` is opt-in for tsserver
- Added as excluded tool (`_typescript.nix`) with `hasTelemetry = false`

Closes #74