### PR TITLE
Exclude tailwindcss: no telemetry

### DIFF
--- a/tools/_tailwindcss.nix
+++ b/tools/_tailwindcss.nix
@@ -1,0 +1,13 @@
+{
+  name = "tailwindcss";
+  meta = {
+    description = "Utility-first CSS framework";
+    homepage = "https://github.com/tailwindlabs/tailwindcss";
+    documentation = "https://github.com/tailwindlabs/tailwindcss";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated tailwindcss for telemetry opt-out
- Tailwind CSS does not collect analytics or telemetry data
- Added as excluded tool (`_tailwindcss.nix`) with `hasTelemetry = false`

Closes #73