### PR TITLE
Exclude tailwind-merge: no telemetry

### DIFF
--- a/tools/_tailwind-merge.nix
+++ b/tools/_tailwind-merge.nix
@@ -1,0 +1,13 @@
+{
+  name = "tailwind-merge";
+  meta = {
+    description = "Utility function to merge Tailwind CSS classes without style conflicts";
+    homepage = "https://github.com/dcastil/tailwind-merge";
+    documentation = "https://github.com/dcastil/tailwind-merge";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated tailwind-merge for telemetry opt-out
- tailwind-merge is a utility library with no telemetry
- Added as excluded tool (`_tailwind-merge.nix`) with `hasTelemetry = false`

Closes #72