### PR TITLE
Exclude react-dom: no telemetry

### DIFF
--- a/tools/_react-dom.nix
+++ b/tools/_react-dom.nix
@@ -1,0 +1,13 @@
+{
+  name = "react-dom";
+  meta = {
+    description = "Entry point to the DOM and server renderers for React";
+    homepage = "https://github.com/facebook/react";
+    documentation = "https://github.com/facebook/react";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated react-dom for telemetry opt-out
- React DOM does not collect analytics or telemetry data
- Added as excluded tool (`_react-dom.nix`) with `hasTelemetry = false`

Closes #71