### PR TITLE
Exclude radix-ui: no telemetry

### DIFF
--- a/tools/_radix-ui.nix
+++ b/tools/_radix-ui.nix
@@ -1,0 +1,13 @@
+{
+  name = "radix-ui";
+  meta = {
+    description = "Unstyled, accessible UI component primitives";
+    homepage = "https://github.com/radix-ui/primitives";
+    documentation = "https://github.com/radix-ui/primitives";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated Radix UI Primitives for telemetry opt-out
- Radix UI is a headless component library with no telemetry
- Added as excluded tool (`_radix-ui.nix`) with `hasTelemetry = false`

Closes #69