### PR TITLE
Exclude nodemon: no telemetry

### DIFF
--- a/tools/_nodemon.nix
+++ b/tools/_nodemon.nix
@@ -1,0 +1,13 @@
+{
+  name = "nodemon";
+  meta = {
+    description = "Monitor for changes in Node.js applications and automatically restart the server";
+    homepage = "https://github.com/remy/nodemon";
+    documentation = "https://github.com/remy/nodemon";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated nodemon for telemetry opt-out
- nodemon is a file watcher with no telemetry
- Added as excluded tool (`_nodemon.nix`) with `hasTelemetry = false`

Closes #68