### PR TITLE
Exclude lucide-react: no telemetry

### DIFF
--- a/tools/_lucide-react.nix
+++ b/tools/_lucide-react.nix
@@ -1,0 +1,13 @@
+{
+  name = "lucide-react";
+  meta = {
+    description = "Beautiful and consistent icon library";
+    homepage = "https://github.com/lucide-icons/lucide";
+    documentation = "https://github.com/lucide-icons/lucide";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated lucide-react for telemetry opt-out
- Lucide is an icon library with no telemetry
- Added as excluded tool (`_lucide-react.nix`) with `hasTelemetry = false`

Closes #66