### PR TITLE
Exclude jsdom: no telemetry

### DIFF
--- a/tools/_jsdom.nix
+++ b/tools/_jsdom.nix
@@ -1,0 +1,13 @@
+{
+  name = "jsdom";
+  meta = {
+    description = "JavaScript implementation of various web standards for use with Node.js";
+    homepage = "https://github.com/jsdom/jsdom";
+    documentation = "https://github.com/jsdom/jsdom";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated jsdom for telemetry opt-out
- jsdom is a DOM implementation library with no telemetry
- Added as excluded tool (`_jsdom.nix`) with `hasTelemetry = false`

Closes #65