### PR TITLE
Exclude electron-store: no telemetry

### DIFF
--- a/tools/_electron-store.nix
+++ b/tools/_electron-store.nix
@@ -1,0 +1,13 @@
+{
+  name = "electron-store";
+  meta = {
+    description = "Simple data persistence for Electron applications";
+    homepage = "https://github.com/sindresorhus/electron-store";
+    documentation = "https://github.com/sindresorhus/electron-store";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated electron-store for telemetry opt-out
- electron-store is a data persistence library with no telemetry
- Added as excluded tool (`_electron-store.nix`) with `hasTelemetry = false`

Closes #64