### PR TITLE
Exclude electron: no telemetry

### DIFF
--- a/tools/_electron.nix
+++ b/tools/_electron.nix
@@ -1,0 +1,13 @@
+{
+  name = "electron";
+  meta = {
+    description = "Framework for building cross-platform desktop applications with web technologies";
+    homepage = "https://github.com/electron/electron";
+    documentation = "https://github.com/electron/electron";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated Electron for telemetry opt-out
- Electron the framework does not collect its own telemetry — crash reporting APIs are for app developers to use
- Added as excluded tool (`_electron.nix`) with `hasTelemetry = false`

Closes #63