### PR TITLE
Exclude clsx: no telemetry

### DIFF
--- a/tools/_clsx.nix
+++ b/tools/_clsx.nix
@@ -1,0 +1,13 @@
+{
+  name = "clsx";
+  meta = {
+    description = "Tiny utility for constructing className strings conditionally";
+    homepage = "https://github.com/lukeed/clsx";
+    documentation = "https://github.com/lukeed/clsx";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated clsx for telemetry opt-out
- clsx is a tiny className utility with no telemetry
- Added as excluded tool (`_clsx.nix`) with `hasTelemetry = false`

Closes #62