### PR TITLE
Exclude class-variance-authority: no telemetry

### DIFF
--- a/tools/_class-variance-authority.nix
+++ b/tools/_class-variance-authority.nix
@@ -1,0 +1,13 @@
+{
+  name = "class-variance-authority";
+  meta = {
+    description = "Class variance authority for creating variant-based CSS class utilities";
+    homepage = "https://github.com/joe-bell/cva";
+    documentation = "https://github.com/joe-bell/cva";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated class-variance-authority for telemetry opt-out
- CVA is a CSS class utility library with no telemetry
- Added as excluded tool (`_class-variance-authority.nix`) with `hasTelemetry = false`

Closes #61