### PR TITLE
Exclude @vitest/ui: no telemetry

### DIFF
--- a/tools/_vitest-ui.nix
+++ b/tools/_vitest-ui.nix
@@ -1,0 +1,13 @@
+{
+  name = "vitest-ui";
+  meta = {
+    description = "UI dashboard for the Vitest testing framework";
+    homepage = "https://github.com/vitest-dev/vitest";
+    documentation = "https://github.com/vitest-dev/vitest";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated @vitest/ui for telemetry opt-out
- @vitest/ui is a test UI dashboard with no telemetry
- Added as excluded tool (`_vitest-ui.nix`) with `hasTelemetry = false`

Closes #60