### PR TITLE
Exclude @vitejs/plugin-react: no telemetry

### DIFF
--- a/tools/_vitejs-plugin-react.nix
+++ b/tools/_vitejs-plugin-react.nix
@@ -1,0 +1,13 @@
+{
+  name = "vitejs-plugin-react";
+  meta = {
+    description = "Official Vite plugin for React with Fast Refresh support";
+    homepage = "https://github.com/vitejs/vite-plugin-react";
+    documentation = "https://github.com/vitejs/vite-plugin-react";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated @vitejs/plugin-react for telemetry opt-out
- Vite React plugin is a build plugin with no telemetry
- Added as excluded tool (`_vitejs-plugin-react.nix`) with `hasTelemetry = false`

Closes #59