### PR TITLE
Exclude @types/react: no telemetry

### DIFF
--- a/tools/_types-react.nix
+++ b/tools/_types-react.nix
@@ -1,0 +1,13 @@
+{
+  name = "types-react";
+  meta = {
+    description = "TypeScript type definitions for React";
+    homepage = "https://github.com/DefinitelyTyped/DefinitelyTyped";
+    documentation = "https://github.com/DefinitelyTyped/DefinitelyTyped";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated @types/react for telemetry opt-out
- TypeScript type definitions contain no runtime code and no telemetry
- Added as excluded tool (`_types-react.nix`) with `hasTelemetry = false`

Closes #57