### PR TITLE
Exclude @testing-library/user-event: no telemetry

### DIFF
--- a/tools/_testing-library-user-event.nix
+++ b/tools/_testing-library-user-event.nix
@@ -1,0 +1,13 @@
+{
+  name = "testing-library-user-event";
+  meta = {
+    description = "Simulate user events for testing";
+    homepage = "https://github.com/testing-library/user-event";
+    documentation = "https://github.com/testing-library/user-event";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated @testing-library/user-event for telemetry opt-out
- Testing utility library with no telemetry
- Added as excluded tool (`_testing-library-user-event.nix`) with `hasTelemetry = false`

Closes #56