### PR TITLE
Exclude @testing-library/jest-dom: no telemetry

### DIFF
--- a/tools/_testing-library-jest-dom.nix
+++ b/tools/_testing-library-jest-dom.nix
@@ -1,0 +1,13 @@
+{
+  name = "testing-library-jest-dom";
+  meta = {
+    description = "Custom Jest matchers for testing the state of the DOM";
+    homepage = "https://github.com/testing-library/jest-dom";
+    documentation = "https://github.com/testing-library/jest-dom";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated @testing-library/jest-dom for telemetry opt-out
- Testing matcher library with no telemetry
- Added as excluded tool (`_testing-library-jest-dom.nix`) with `hasTelemetry = false`

Closes #54