### PR TITLE
Exclude @tanstack/router-plugin: no telemetry

### DIFF
--- a/tools/_tanstack-router-plugin.nix
+++ b/tools/_tanstack-router-plugin.nix
@@ -1,0 +1,13 @@
+{
+  name = "tanstack-router-plugin";
+  meta = {
+    description = "Build plugin for TanStack Router with file-based routing";
+    homepage = "https://github.com/TanStack/router";
+    documentation = "https://github.com/TanStack/router";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated @tanstack/router-plugin for telemetry opt-out
- Build plugin for TanStack Router with no telemetry
- Added as excluded tool (`_tanstack-router-plugin.nix`) with `hasTelemetry = false`

Closes #53