### PR TITLE
Exclude @tanstack/router-devtools: no telemetry

### DIFF
--- a/tools/_tanstack-router-devtools.nix
+++ b/tools/_tanstack-router-devtools.nix
@@ -1,0 +1,13 @@
+{
+  name = "tanstack-router-devtools";
+  meta = {
+    description = "Developer tools for debugging TanStack Router";
+    homepage = "https://github.com/TanStack/router";
+    documentation = "https://github.com/TanStack/router";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated @tanstack/router-devtools for telemetry opt-out
- Devtools component with no telemetry
- Added as excluded tool (`_tanstack-router-devtools.nix`) with `hasTelemetry = false`

Closes #52