### PR TITLE
Exclude @tanstack/react-router: no telemetry

### DIFF
--- a/tools/_tanstack-react-router.nix
+++ b/tools/_tanstack-react-router.nix
@@ -1,0 +1,13 @@
+{
+  name = "tanstack-react-router";
+  meta = {
+    description = "Type-safe routing library with built-in data fetching";
+    homepage = "https://github.com/TanStack/router";
+    documentation = "https://github.com/TanStack/router";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated @tanstack/react-router for telemetry opt-out
- Routing library with no telemetry
- Added as excluded tool (`_tanstack-react-router.nix`) with `hasTelemetry = false`

Closes #51