### PR TITLE
Exclude @tailwindcss/vite: no telemetry

### DIFF
--- a/tools/_tailwindcss-vite.nix
+++ b/tools/_tailwindcss-vite.nix
@@ -1,0 +1,13 @@
+{
+  name = "tailwindcss-vite";
+  meta = {
+    description = "Vite plugin for Tailwind CSS";
+    homepage = "https://github.com/tailwindlabs/tailwindcss";
+    documentation = "https://github.com/tailwindlabs/tailwindcss";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated @tailwindcss/vite for telemetry opt-out
- Vite plugin for Tailwind CSS with no telemetry
- Added as excluded tool (`_tailwindcss-vite.nix`) with `hasTelemetry = false`

Closes #50