### PR TITLE
Exclude @electron/fuses: no telemetry

### DIFF
--- a/tools/_electron-fuses.nix
+++ b/tools/_electron-fuses.nix
@@ -1,0 +1,13 @@
+{
+  name = "electron-fuses";
+  meta = {
+    description = "Library for flipping Electron fuses to enable or disable features";
+    homepage = "https://github.com/electron/fuses";
+    documentation = "https://github.com/electron/fuses";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated @electron/fuses for telemetry opt-out
- Library for flipping Electron fuses with no telemetry
- Added as excluded tool (`_electron-fuses.nix`) with `hasTelemetry = false`

Closes #49