### PR TITLE
Exclude @electron-forge/publisher-s3: no telemetry

### DIFF
--- a/tools/_electron-forge-publisher-s3.nix
+++ b/tools/_electron-forge-publisher-s3.nix
@@ -1,0 +1,13 @@
+{
+  name = "electron-forge-publisher-s3";
+  meta = {
+    description = "Electron Forge publisher for uploading artifacts to Amazon S3";
+    homepage = "https://github.com/electron/forge";
+    documentation = "https://github.com/electron/forge";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated @electron-forge/publisher-s3 for telemetry opt-out
- Electron Forge publisher plugin with no telemetry
- Added as excluded tool (`_electron-forge-publisher-s3.nix`) with `hasTelemetry = false`

Closes #48