### PR TITLE
Exclude @electron-forge/publisher-github: no telemetry

### DIFF
--- a/tools/_electron-forge-publisher-github.nix
+++ b/tools/_electron-forge-publisher-github.nix
@@ -1,0 +1,13 @@
+{
+  name = "electron-forge-publisher-github";
+  meta = {
+    description = "Electron Forge publisher for uploading artifacts to GitHub Releases";
+    homepage = "https://github.com/electron/forge";
+    documentation = "https://github.com/electron/forge";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated @electron-forge/publisher-github for telemetry opt-out
- Electron Forge publisher plugin with no telemetry
- Added as excluded tool (`_electron-forge-publisher-github.nix`) with `hasTelemetry = false`

Closes #47