### PR TITLE
Exclude @electron-forge/plugin-vite: no telemetry

### DIFF
--- a/tools/_electron-forge-plugin-vite.nix
+++ b/tools/_electron-forge-plugin-vite.nix
@@ -1,0 +1,13 @@
+{
+  name = "electron-forge-plugin-vite";
+  meta = {
+    description = "Electron Forge plugin for building applications with Vite";
+    homepage = "https://github.com/electron/forge";
+    documentation = "https://github.com/electron/forge";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated @electron-forge/plugin-vite for telemetry opt-out
- Electron Forge plugin with no telemetry
- Added as excluded tool (`_electron-forge-plugin-vite.nix`) with `hasTelemetry = false`

Closes #46