### PR TITLE
Exclude @electron-forge/plugin-fuses: no telemetry

### DIFF
--- a/tools/_electron-forge-plugin-fuses.nix
+++ b/tools/_electron-forge-plugin-fuses.nix
@@ -1,0 +1,13 @@
+{
+  name = "electron-forge-plugin-fuses";
+  meta = {
+    description = "Electron Forge plugin for configuring Electron fuses";
+    homepage = "https://github.com/electron/forge";
+    documentation = "https://github.com/electron/forge";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated @electron-forge/plugin-fuses for telemetry opt-out
- Electron Forge plugin with no telemetry
- Added as excluded tool (`_electron-forge-plugin-fuses.nix`) with `hasTelemetry = false`

Closes #45