### PR TITLE
Exclude @electron-forge/plugin-auto-unpack-natives: no telemetry

### DIFF
--- a/tools/_electron-forge-plugin-auto-unpack-natives.nix
+++ b/tools/_electron-forge-plugin-auto-unpack-natives.nix
@@ -1,0 +1,13 @@
+{
+  name = "electron-forge-plugin-auto-unpack-natives";
+  meta = {
+    description = "Electron Forge plugin that automatically unpacks native Node modules";
+    homepage = "https://github.com/electron/forge";
+    documentation = "https://github.com/electron/forge";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated @electron-forge/plugin-auto-unpack-natives for telemetry opt-out
- Electron Forge plugin with no telemetry
- Added as excluded tool (`_electron-forge-plugin-auto-unpack-natives.nix`) with `hasTelemetry = false`

Closes #44