### PR TITLE
Exclude @electron-forge/maker-zip: no telemetry

### DIFF
--- a/tools/_electron-forge-maker-zip.nix
+++ b/tools/_electron-forge-maker-zip.nix
@@ -1,0 +1,13 @@
+{
+  name = "electron-forge-maker-zip";
+  meta = {
+    description = "Electron Forge maker for creating ZIP archives";
+    homepage = "https://github.com/electron/forge";
+    documentation = "https://github.com/electron/forge";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated @electron-forge/maker-zip for telemetry opt-out
- Electron Forge maker with no telemetry
- Added as excluded tool (`_electron-forge-maker-zip.nix`) with `hasTelemetry = false`

Closes #43