### PR TITLE
Exclude @electron-forge/maker-deb: no telemetry

### DIFF
--- a/tools/_electron-forge-maker-deb.nix
+++ b/tools/_electron-forge-maker-deb.nix
@@ -1,0 +1,13 @@
+{
+  name = "electron-forge-maker-deb";
+  meta = {
+    description = "Electron Forge maker for creating Debian packages";
+    homepage = "https://github.com/electron/forge";
+    documentation = "https://github.com/electron/forge";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated @electron-forge/maker-deb for telemetry opt-out
- Electron Forge maker with no telemetry
- Added as excluded tool (`_electron-forge-maker-deb.nix`) with `hasTelemetry = false`

Closes #41