### PR TITLE
Exclude @electron-forge/cli: no telemetry

### DIFF
--- a/tools/_electron-forge-cli.nix
+++ b/tools/_electron-forge-cli.nix
@@ -1,0 +1,13 @@
+{
+  name = "electron-forge-cli";
+  meta = {
+    description = "Command-line interface for Electron Forge";
+    homepage = "https://github.com/electron/forge";
+    documentation = "https://github.com/electron/forge";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated @electron-forge/cli for telemetry opt-out
- Electron Forge CLI with no telemetry
- Added as excluded tool (`_electron-forge-cli.nix`) with `hasTelemetry = false`

Closes #40