### PR TITLE
Exclude @biomejs/biome: no telemetry

### DIFF
--- a/tools/_biomejs-biome.nix
+++ b/tools/_biomejs-biome.nix
@@ -1,0 +1,13 @@
+{
+  name = "biomejs-biome";
+  meta = {
+    description = "Performant toolchain for web projects providing formatting, linting, and more";
+    homepage = "https://github.com/biomejs/biome";
+    documentation = "https://github.com/biomejs/biome";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated @biomejs/biome for telemetry opt-out
- Biome is a web toolchain with no telemetry
- Added as excluded tool (`_biomejs-biome.nix`) with `hasTelemetry = false`

Closes #39