### PR TITLE
Exclude @astrojs/cloudflare: no telemetry

### DIFF
--- a/tools/_astrojs-cloudflare.nix
+++ b/tools/_astrojs-cloudflare.nix
@@ -1,0 +1,13 @@
+{
+  name = "astrojs-cloudflare";
+  meta = {
+    description = "Astro adapter for deploying to Cloudflare";
+    homepage = "https://github.com/withastro/adapters";
+    documentation = "https://github.com/withastro/adapters";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated @astrojs/cloudflare for telemetry opt-out
- Astro Cloudflare adapter with no telemetry (Astro's telemetry is already covered by the astro tool)
- Added as excluded tool (`_astrojs-cloudflare.nix`) with `hasTelemetry = false`

Closes #38