### PR TITLE
Exclude govulncheck: CLI-only telemetry opt-out

### DIFF
--- a/tools/_govulncheck.nix
+++ b/tools/_govulncheck.nix
@@ -1,15 +1,16 @@
 {
   name = "govulncheck";
   meta = {
-    description = "Vulnerability scanner for Go projects that reports known vulnerabilities in dependencies";
+    description = "Go vulnerability scanner for finding known vulnerabilities in dependencies";
     homepage = "https://github.com/golang/vuln";
     documentation = "https://go.dev/doc/telemetry";
-    lastChecked = "2026-03-14";
+    lastChecked = "2026-03-28";
     hasTelemetry = true;
   };
   variables = { };
   commands = {
     disable = "go telemetry off";
+    status = "go telemetry";
   };
   config = { };
 }


### PR DESCRIPTION
## Summary
- Investigated govulncheck for telemetry opt-out
- Uses Go's telemetry system (`golang.org/x/telemetry`) — opt-out is via `go telemetry off` CLI command only
- `GOTELEMETRY` is a non-settable Go env variable (read-only), not an environment variable opt-out
- Added as excluded tool (`_govulncheck.nix`) with `hasTelemetry = true`

Closes #27