### PR TITLE
Exclude gofumpt: no telemetry

### DIFF
--- a/tools/_gofumpt.nix
+++ b/tools/_gofumpt.nix
@@ -1,0 +1,13 @@
+{
+  name = "gofumpt";
+  meta = {
+    description = "Stricter gofmt-compatible Go code formatter";
+    homepage = "https://github.com/mvdan/gofumpt";
+    documentation = "https://github.com/mvdan/gofumpt";
+    lastChecked = "2026-03-28";
+    hasTelemetry = false;
+  };
+  variables = { };
+  commands = { };
+  config = { };
+}


### PR DESCRIPTION
## Summary
- Investigated gofumpt for telemetry opt-out
- gofumpt is a Go code formatter with no telemetry
- Added as excluded tool (`_gofumpt.nix`) with `hasTelemetry = false`

Closes #22